### PR TITLE
Add Shopware stack skeleton

### DIFF
--- a/AcmeCsp-Shopware-Stack/.editorconfig
+++ b/AcmeCsp-Shopware-Stack/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/AcmeCsp-Shopware-Stack/.gitignore
+++ b/AcmeCsp-Shopware-Stack/.gitignore
@@ -1,0 +1,8 @@
+/vendor/
+/composer.lock
+/.idea/
+/node_modules/
+/var/
+/public/bundles/
+/.ENV
+.DS_Store

--- a/AcmeCsp-Shopware-Stack/.gitlab-ci.yml
+++ b/AcmeCsp-Shopware-Stack/.gitlab-ci.yml
@@ -1,0 +1,25 @@
+stages: [lint, test, build]
+
+phpstan:
+  stage: lint
+  image: php:8.2-cli
+  script:
+    - curl -Ls https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar -o phpstan
+    - php phpstan --version
+    - php phpstan analyse
+
+phpunit:
+  stage: test
+  image: php:8.2-cli
+  script:
+    - curl -Ls https://phar.phpunit.de/phpunit-10.phar -o phpunit
+    - php phpunit --version
+    - php phpunit
+
+package:
+  stage: build
+  image: alpine:3.19
+  script:
+    - zip -r build.zip plugins shared README.md ROADMAP.md ADRs -x "**/vendor/*"
+  artifacts:
+    paths: [build.zip]

--- a/AcmeCsp-Shopware-Stack/ADRs/0001-template.md
+++ b/AcmeCsp-Shopware-Stack/ADRs/0001-template.md
@@ -1,0 +1,12 @@
+# ADR: <Kurzer Titel>
+Datum: YYYY-MM-DD
+Status: Proposed | Accepted | Superseded
+
+## Kontext
+<Problemstellung/Entscheidungskontext kurz beschreiben>
+
+## Entscheidung
+<Was wird entschieden?>
+
+## Konsequenzen
+<Trade-offs, Risiken, Follow-ups>

--- a/AcmeCsp-Shopware-Stack/README.md
+++ b/AcmeCsp-Shopware-Stack/README.md
@@ -1,0 +1,12 @@
+# Generic Service-Portal Stack (Shopware 6)
+
+Zweck: Vorbereitete Modulbibliothek für B2B/Public-Sector-Anforderungen auf Shopware-Basis.
+Kein Kundennamen. Allgemeine Problemstellung:
+- Shopware OOTB deckt Governance/B2B-Anforderungen (Rollen, Genehmigungen, Mandanten, E-Rechnung, SSO, Audit) nicht vollständig ab.
+- Ziel: Service-Portal (Bestellung = Antrag + Genehmigungen + Provisionierung) mit strengen Compliance-Vorgaben.
+
+Struktur:
+- /plugins/<Module> : eigenständige Shopware-Plugins (Scaffolds)
+- /shared : wiederverwendbare Helpers/DTOs/Policies
+- ROADMAP.md : empfohlene Umsetzungsreihenfolge & Best Practices
+- ADRs/ : Architecture Decision Records

--- a/AcmeCsp-Shopware-Stack/ROADMAP.md
+++ b/AcmeCsp-Shopware-Stack/ROADMAP.md
@@ -1,0 +1,34 @@
+# Roadmap (Entwurf)
+
+## Phase 0 – Infrastruktur
+- PSR-12, PHPStan (level max sinnvoll), PHPUnit
+- CI: Lint, Stan, Test, Build/Package
+
+## Phase 1 – Kern-Governance
+- RolesPermissions (ACL-Erweiterung/Policy-Voter)
+- ApprovalWorkflow (mehrstufige Freigaben, Eskalation)
+- MandateManagement (Mandanten/Branding/Trennung)
+
+## Phase 2 – Commerce/Finanzen
+- CostCenters (Kostenstellen im Antrag/Checkout + Export)
+- InvoicingXRechnung (XRechnung/ZUGFeRD Hooks)
+- ErpIntegration (SAP/MACH Adapter, Outbox/Inbox)
+
+## Phase 3 – Integrationen
+- BrokerIntegration (Cloud-Broker API)
+- SsoIdm (SAML/OIDC Anbindung, Rollen-Sync)
+
+## Phase 4 – UX & Compliance
+- CustomForms (Service-Anträge, Draft/Resume)
+- Accessibility (WCAG/BITV Helpers)
+- ThemingBranding (Mandanten-Themes)
+
+## Phase 5 – Betrieb & Nachweis
+- AuditLogging (revisionssichere Trails)
+- Monitoring (Health/Metrics/Tracing)
+- DrBackup (Backup/Restore/DR-Doku)
+
+Querschnitt:
+- Security (CSP, Nonces, Input-Hardening)
+- Tests (Unit/Integration/E2E)
+- Docs pro Modul (README, ADR)

--- a/AcmeCsp-Shopware-Stack/composer.json
+++ b/AcmeCsp-Shopware-Stack/composer.json
@@ -1,0 +1,15 @@
+{
+  "name": "acme/csp-stack",
+  "type": "project",
+  "description": "Generic Shopware plugin stack for B2B/Public Sector service-portal use cases.",
+  "license": "proprietary",
+  "require": {
+    "php": ">=8.1",
+    "ext-json": "*"
+  },
+  "autoload": {
+    "psr-4": {
+      "Acme\Csp\Shared\": "shared/src/"
+    }
+  }
+}

--- a/AcmeCsp-Shopware-Stack/phpstan.neon
+++ b/AcmeCsp-Shopware-Stack/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+  level: 6
+  paths:
+    - plugins
+    - shared/src
+  checkGenericClassInNonGenericObjectType: false

--- a/AcmeCsp-Shopware-Stack/phpunit.xml.dist
+++ b/AcmeCsp-Shopware-Stack/phpunit.xml.dist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory>./plugins/*/tests</directory>
+      <directory>./shared/tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/AcmeCsp-Shopware-Stack/plugins/Accessibility/README.md
+++ b/AcmeCsp-Shopware-Stack/plugins/Accessibility/README.md
@@ -1,0 +1,13 @@
+# Accessibility (Shopware Plugin)
+
+Problemstellung (allgemein):
+B2B/Public-Sector Portale benötigen Governance/Compliance/Integrationen, die Shopware OOTB nicht vollständig liefert.
+
+Ziel:
+Grundgerüst (Domain/DI/Events/API) zur schnellen Ergänzung projektspezifischer Business-Logik.
+
+Best Practices:
+- Keine Core-Hacks; Events/Subscriber/Decorators verwenden.
+- DAL statt direkter SQL-Zugriffe (außer Migrationen).
+- System-Config/Policies dokumentieren.
+- Unit/Integration-Tests früh anlegen.

--- a/AcmeCsp-Shopware-Stack/plugins/Accessibility/composer.json
+++ b/AcmeCsp-Shopware-Stack/plugins/Accessibility/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "acme/shopware-accessibility",
+  "type": "shopware-platform-plugin",
+  "description": "Accessibility plugin scaffold",
+  "license": "proprietary",
+  "require": {
+    "php": ">=8.1",
+    "shopware/core": "^6.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "Acme\\Csp\\Accessibility\": "src/"
+    }
+  },
+  "extra": {
+    "shopware-plugin-class": "Acme\\Csp\\Accessibility\Accessibility",
+    "label": "Accessibility (Scaffold)"
+  }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/Accessibility/phpunit.xml.dist
+++ b/AcmeCsp-Shopware-Stack/plugins/Accessibility/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/AcmeCsp-Shopware-Stack/plugins/Accessibility/src/Accessibility.php
+++ b/AcmeCsp-Shopware-Stack/plugins/Accessibility/src/Accessibility.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\Accessibility;
+
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\Context\InstallContext;
+
+final class Accessibility extends Plugin
+{
+    public function install(InstallContext $installContext): void
+    {
+        parent::install($installContext);
+        // TODO: migrations, system config, ACL seeds
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/Accessibility/src/Domain/Service/AccessibilityFacade.php
+++ b/AcmeCsp-Shopware-Stack/plugins/Accessibility/src/Domain/Service/AccessibilityFacade.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\Accessibility\Domain\Service;
+
+use Psr\Log\LoggerInterface;
+
+final class AccessibilityFacade
+{
+    public function __construct(private readonly LoggerInterface $logger) {}
+
+    public function demo(): void
+    {
+        $this->logger->info('Accessibility: scaffold operational');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/Accessibility/src/Infrastructure/Api/AccessibilityPingController.php
+++ b/AcmeCsp-Shopware-Stack/plugins/Accessibility/src/Infrastructure/Api/AccessibilityPingController.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\Accessibility\Infrastructure\Api;
+
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Route(defaults: ['_routeScope' => ['storefront']])]
+final class AccessibilityPingController
+{
+    #[Route(path: '/api/accessibility/ping', name: 'accessibility.ping', methods: ['GET'])]
+    public function ping(): Response
+    {
+        return new Response('Accessibility OK');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/Accessibility/src/Infrastructure/Event/AccessibilitySubscriber.php
+++ b/AcmeCsp-Shopware-Stack/plugins/Accessibility/src/Infrastructure/Event/AccessibilitySubscriber.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\Accessibility\Infrastructure\Event;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class AccessibilitySubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // Shopware/Core events hier eintragen
+        ];
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/Accessibility/src/Resources/app/administration/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/Accessibility/src/Resources/app/administration/src/main.js
@@ -1,0 +1,1 @@
+import './module'; // extend administration here

--- a/AcmeCsp-Shopware-Stack/plugins/Accessibility/src/Resources/app/storefront/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/Accessibility/src/Resources/app/storefront/src/main.js
@@ -1,0 +1,1 @@
+// storefront enhancements here

--- a/AcmeCsp-Shopware-Stack/plugins/Accessibility/src/Resources/config/config.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/Accessibility/src/Resources/config/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/System/SystemConfig/Schema/config.xsd">
+  <card>
+    <title>Accessibility Settings</title>
+    <input-field type="text" name="accessibility.example" label="Example setting"/>
+  </card>
+</config>

--- a/AcmeCsp-Shopware-Stack/plugins/Accessibility/src/Resources/config/services.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/Accessibility/src/Resources/config/services.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+           https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="Acme\Csp\Accessibility\Domain\Service\AccessibilityFacade" public="true">
+      <argument type="service" id="logger"/>
+    </service>
+
+    <service id="Acme\Csp\Accessibility\Infrastructure\Api\AccessibilityPingController" public="true">
+      <tag name="controller.service_arguments"/>
+    </service>
+
+    <service id="Acme\Csp\Accessibility\Infrastructure\Event\AccessibilitySubscriber">
+      <tag name="kernel.event_subscriber"/>
+    </service>
+  </services>
+</container>

--- a/AcmeCsp-Shopware-Stack/plugins/Accessibility/tests/ExampleTest.php
+++ b/AcmeCsp-Shopware-Stack/plugins/Accessibility/tests/ExampleTest.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class ExampleTest extends TestCase
+{
+    public function testScaffold(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/README.md
+++ b/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/README.md
@@ -1,0 +1,13 @@
+# ApprovalWorkflow (Shopware Plugin)
+
+Problemstellung (allgemein):
+B2B/Public-Sector Portale benötigen Governance/Compliance/Integrationen, die Shopware OOTB nicht vollständig liefert.
+
+Ziel:
+Grundgerüst (Domain/DI/Events/API) zur schnellen Ergänzung projektspezifischer Business-Logik.
+
+Best Practices:
+- Keine Core-Hacks; Events/Subscriber/Decorators verwenden.
+- DAL statt direkter SQL-Zugriffe (außer Migrationen).
+- System-Config/Policies dokumentieren.
+- Unit/Integration-Tests früh anlegen.

--- a/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/composer.json
+++ b/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "acme/shopware-approvalworkflow",
+  "type": "shopware-platform-plugin",
+  "description": "ApprovalWorkflow plugin scaffold",
+  "license": "proprietary",
+  "require": {
+    "php": ">=8.1",
+    "shopware/core": "^6.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "Acme\\Csp\\ApprovalWorkflow\": "src/"
+    }
+  },
+  "extra": {
+    "shopware-plugin-class": "Acme\\Csp\\ApprovalWorkflow\ApprovalWorkflow",
+    "label": "ApprovalWorkflow (Scaffold)"
+  }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/phpunit.xml.dist
+++ b/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/ApprovalWorkflow.php
+++ b/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/ApprovalWorkflow.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\ApprovalWorkflow;
+
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\Context\InstallContext;
+
+final class ApprovalWorkflow extends Plugin
+{
+    public function install(InstallContext $installContext): void
+    {
+        parent::install($installContext);
+        // TODO: migrations, system config, ACL seeds
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/Core/Content/ApprovalStep/ApprovalStepCollection.php
+++ b/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/Core/Content/ApprovalStep/ApprovalStepCollection.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\ApprovalWorkflow\Core\Content\ApprovalStep;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+
+/**
+ * @method void add(ApprovalStepEntity $entity)
+ * @method void set(string $key, ApprovalStepEntity $entity)
+ * @method ApprovalStepEntity[] getIterator()
+ * @method ApprovalStepEntity[] getElements()
+ * @method ApprovalStepEntity|null get(string $key)
+ * @method ApprovalStepEntity|null first()
+ * @method ApprovalStepEntity|null last()
+ */
+class ApprovalStepCollection extends EntityCollection
+{
+    protected function getExpectedClass(): string
+    {
+        return ApprovalStepEntity::class;
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/Core/Content/ApprovalStep/ApprovalStepDefinition.php
+++ b/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/Core/Content/ApprovalStep/ApprovalStepDefinition.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\ApprovalWorkflow\Core\Content\ApprovalStep;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Collection\FieldCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
+
+final class ApprovalStepDefinition extends EntityDefinition
+{
+    public const ENTITY_NAME = 'acme_csp_approval_step';
+
+    public function getEntityName(): string { return self::ENTITY_NAME; }
+    public function getEntityClass(): string { return ApprovalStepEntity::class; }
+    public function getCollectionClass(): string { return ApprovalStepCollection::class; }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new Required(), new PrimaryKey()),
+            (new StringField('name', 'name'))->addFlags(new Required()),
+            (new IntField('sequence', 'sequence'))->addFlags(new Required())
+        ]);
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/Core/Content/ApprovalStep/ApprovalStepEntity.php
+++ b/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/Core/Content/ApprovalStep/ApprovalStepEntity.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\ApprovalWorkflow\Core\Content\ApprovalStep;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
+
+class ApprovalStepEntity extends Entity
+{
+    use EntityIdTrait;
+
+    protected string $name;
+    protected int $sequence;
+
+    public function getName(): string { return $this->name; }
+    public function setName(string $v): void { $this->name = $v; }
+
+    public function getSequence(): int { return $this->sequence; }
+    public function setSequence(int $v): void { $this->sequence = $v; }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/Domain/Service/ApprovalWorkflowFacade.php
+++ b/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/Domain/Service/ApprovalWorkflowFacade.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\ApprovalWorkflow\Domain\Service;
+
+use Psr\Log\LoggerInterface;
+
+final class ApprovalWorkflowFacade
+{
+    public function __construct(private readonly LoggerInterface $logger) {}
+
+    public function demo(): void
+    {
+        $this->logger->info('ApprovalWorkflow: scaffold operational');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/Infrastructure/Api/ApprovalWorkflowPingController.php
+++ b/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/Infrastructure/Api/ApprovalWorkflowPingController.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\ApprovalWorkflow\Infrastructure\Api;
+
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Route(defaults: ['_routeScope' => ['storefront']])]
+final class ApprovalWorkflowPingController
+{
+    #[Route(path: '/api/approvalworkflow/ping', name: 'approvalworkflow.ping', methods: ['GET'])]
+    public function ping(): Response
+    {
+        return new Response('ApprovalWorkflow OK');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/Infrastructure/Event/ApprovalWorkflowSubscriber.php
+++ b/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/Infrastructure/Event/ApprovalWorkflowSubscriber.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\ApprovalWorkflow\Infrastructure\Event;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class ApprovalWorkflowSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // Shopware/Core events hier eintragen
+        ];
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/Migration/Migration1700000001CreateApprovalStep.php
+++ b/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/Migration/Migration1700000001CreateApprovalStep.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\ApprovalWorkflow\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1700000001CreateApprovalStep extends MigrationStep
+{
+    public function getCreationTimestamp(): int { return 1700000001; }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement('
+            CREATE TABLE IF NOT EXISTS `acme_csp_approval_step` (
+                `id` BINARY(16) NOT NULL,
+                `name` VARCHAR(128) NOT NULL,
+                `sequence` INT NOT NULL,
+                `created_at` DATETIME(3) NOT NULL,
+                `updated_at` DATETIME(3) NULL,
+                PRIMARY KEY (`id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        ');
+    }
+
+    public function updateDestructive(Connection $connection): void {}
+}

--- a/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/Resources/app/administration/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/Resources/app/administration/src/main.js
@@ -1,0 +1,1 @@
+import './module'; // extend administration here

--- a/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/Resources/app/storefront/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/Resources/app/storefront/src/main.js
@@ -1,0 +1,1 @@
+// storefront enhancements here

--- a/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/Resources/config/config.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/Resources/config/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/System/SystemConfig/Schema/config.xsd">
+  <card>
+    <title>ApprovalWorkflow Settings</title>
+    <input-field type="text" name="approvalworkflow.example" label="Example setting"/>
+  </card>
+</config>

--- a/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/Resources/config/services.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/src/Resources/config/services.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+           https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="Acme\Csp\ApprovalWorkflow\Domain\Service\ApprovalWorkflowFacade" public="true">
+      <argument type="service" id="logger"/>
+    </service>
+
+    <service id="Acme\Csp\ApprovalWorkflow\Infrastructure\Api\ApprovalWorkflowPingController" public="true">
+      <tag name="controller.service_arguments"/>
+    </service>
+
+    <service id="Acme\Csp\ApprovalWorkflow\Infrastructure\Event\ApprovalWorkflowSubscriber">
+      <tag name="kernel.event_subscriber"/>
+    </service>
+  </services>
+</container>

--- a/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/tests/ExampleTest.php
+++ b/AcmeCsp-Shopware-Stack/plugins/ApprovalWorkflow/tests/ExampleTest.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class ExampleTest extends TestCase
+{
+    public function testScaffold(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/AuditLogging/README.md
+++ b/AcmeCsp-Shopware-Stack/plugins/AuditLogging/README.md
@@ -1,0 +1,13 @@
+# AuditLogging (Shopware Plugin)
+
+Problemstellung (allgemein):
+B2B/Public-Sector Portale benötigen Governance/Compliance/Integrationen, die Shopware OOTB nicht vollständig liefert.
+
+Ziel:
+Grundgerüst (Domain/DI/Events/API) zur schnellen Ergänzung projektspezifischer Business-Logik.
+
+Best Practices:
+- Keine Core-Hacks; Events/Subscriber/Decorators verwenden.
+- DAL statt direkter SQL-Zugriffe (außer Migrationen).
+- System-Config/Policies dokumentieren.
+- Unit/Integration-Tests früh anlegen.

--- a/AcmeCsp-Shopware-Stack/plugins/AuditLogging/composer.json
+++ b/AcmeCsp-Shopware-Stack/plugins/AuditLogging/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "acme/shopware-auditlogging",
+  "type": "shopware-platform-plugin",
+  "description": "AuditLogging plugin scaffold",
+  "license": "proprietary",
+  "require": {
+    "php": ">=8.1",
+    "shopware/core": "^6.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "Acme\\Csp\\AuditLogging\": "src/"
+    }
+  },
+  "extra": {
+    "shopware-plugin-class": "Acme\\Csp\\AuditLogging\AuditLogging",
+    "label": "AuditLogging (Scaffold)"
+  }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/AuditLogging/phpunit.xml.dist
+++ b/AcmeCsp-Shopware-Stack/plugins/AuditLogging/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/AcmeCsp-Shopware-Stack/plugins/AuditLogging/src/AuditLogging.php
+++ b/AcmeCsp-Shopware-Stack/plugins/AuditLogging/src/AuditLogging.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\AuditLogging;
+
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\Context\InstallContext;
+
+final class AuditLogging extends Plugin
+{
+    public function install(InstallContext $installContext): void
+    {
+        parent::install($installContext);
+        // TODO: migrations, system config, ACL seeds
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/AuditLogging/src/Domain/Service/AuditLoggingFacade.php
+++ b/AcmeCsp-Shopware-Stack/plugins/AuditLogging/src/Domain/Service/AuditLoggingFacade.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\AuditLogging\Domain\Service;
+
+use Psr\Log\LoggerInterface;
+
+final class AuditLoggingFacade
+{
+    public function __construct(private readonly LoggerInterface $logger) {}
+
+    public function demo(): void
+    {
+        $this->logger->info('AuditLogging: scaffold operational');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/AuditLogging/src/Infrastructure/Api/AuditLoggingPingController.php
+++ b/AcmeCsp-Shopware-Stack/plugins/AuditLogging/src/Infrastructure/Api/AuditLoggingPingController.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\AuditLogging\Infrastructure\Api;
+
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Route(defaults: ['_routeScope' => ['storefront']])]
+final class AuditLoggingPingController
+{
+    #[Route(path: '/api/auditlogging/ping', name: 'auditlogging.ping', methods: ['GET'])]
+    public function ping(): Response
+    {
+        return new Response('AuditLogging OK');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/AuditLogging/src/Infrastructure/Event/AuditLoggingSubscriber.php
+++ b/AcmeCsp-Shopware-Stack/plugins/AuditLogging/src/Infrastructure/Event/AuditLoggingSubscriber.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\AuditLogging\Infrastructure\Event;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class AuditLoggingSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // Shopware/Core events hier eintragen
+        ];
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/AuditLogging/src/Resources/app/administration/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/AuditLogging/src/Resources/app/administration/src/main.js
@@ -1,0 +1,1 @@
+import './module'; // extend administration here

--- a/AcmeCsp-Shopware-Stack/plugins/AuditLogging/src/Resources/app/storefront/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/AuditLogging/src/Resources/app/storefront/src/main.js
@@ -1,0 +1,1 @@
+// storefront enhancements here

--- a/AcmeCsp-Shopware-Stack/plugins/AuditLogging/src/Resources/config/config.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/AuditLogging/src/Resources/config/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/System/SystemConfig/Schema/config.xsd">
+  <card>
+    <title>AuditLogging Settings</title>
+    <input-field type="text" name="auditlogging.example" label="Example setting"/>
+  </card>
+</config>

--- a/AcmeCsp-Shopware-Stack/plugins/AuditLogging/src/Resources/config/services.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/AuditLogging/src/Resources/config/services.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+           https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="Acme\Csp\AuditLogging\Domain\Service\AuditLoggingFacade" public="true">
+      <argument type="service" id="logger"/>
+    </service>
+
+    <service id="Acme\Csp\AuditLogging\Infrastructure\Api\AuditLoggingPingController" public="true">
+      <tag name="controller.service_arguments"/>
+    </service>
+
+    <service id="Acme\Csp\AuditLogging\Infrastructure\Event\AuditLoggingSubscriber">
+      <tag name="kernel.event_subscriber"/>
+    </service>
+  </services>
+</container>

--- a/AcmeCsp-Shopware-Stack/plugins/AuditLogging/tests/ExampleTest.php
+++ b/AcmeCsp-Shopware-Stack/plugins/AuditLogging/tests/ExampleTest.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class ExampleTest extends TestCase
+{
+    public function testScaffold(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/README.md
+++ b/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/README.md
@@ -1,0 +1,13 @@
+# BrokerIntegration (Shopware Plugin)
+
+Problemstellung (allgemein):
+B2B/Public-Sector Portale benötigen Governance/Compliance/Integrationen, die Shopware OOTB nicht vollständig liefert.
+
+Ziel:
+Grundgerüst (Domain/DI/Events/API) zur schnellen Ergänzung projektspezifischer Business-Logik.
+
+Best Practices:
+- Keine Core-Hacks; Events/Subscriber/Decorators verwenden.
+- DAL statt direkter SQL-Zugriffe (außer Migrationen).
+- System-Config/Policies dokumentieren.
+- Unit/Integration-Tests früh anlegen.

--- a/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/composer.json
+++ b/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "acme/shopware-brokerintegration",
+  "type": "shopware-platform-plugin",
+  "description": "BrokerIntegration plugin scaffold",
+  "license": "proprietary",
+  "require": {
+    "php": ">=8.1",
+    "shopware/core": "^6.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "Acme\\Csp\\BrokerIntegration\": "src/"
+    }
+  },
+  "extra": {
+    "shopware-plugin-class": "Acme\\Csp\\BrokerIntegration\BrokerIntegration",
+    "label": "BrokerIntegration (Scaffold)"
+  }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/phpunit.xml.dist
+++ b/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/src/BrokerIntegration.php
+++ b/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/src/BrokerIntegration.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\BrokerIntegration;
+
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\Context\InstallContext;
+
+final class BrokerIntegration extends Plugin
+{
+    public function install(InstallContext $installContext): void
+    {
+        parent::install($installContext);
+        // TODO: migrations, system config, ACL seeds
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/src/Domain/Service/BrokerIntegrationFacade.php
+++ b/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/src/Domain/Service/BrokerIntegrationFacade.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\BrokerIntegration\Domain\Service;
+
+use Psr\Log\LoggerInterface;
+
+final class BrokerIntegrationFacade
+{
+    public function __construct(private readonly LoggerInterface $logger) {}
+
+    public function demo(): void
+    {
+        $this->logger->info('BrokerIntegration: scaffold operational');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/src/Infrastructure/Api/BrokerIntegrationPingController.php
+++ b/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/src/Infrastructure/Api/BrokerIntegrationPingController.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\BrokerIntegration\Infrastructure\Api;
+
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Route(defaults: ['_routeScope' => ['storefront']])]
+final class BrokerIntegrationPingController
+{
+    #[Route(path: '/api/brokerintegration/ping', name: 'brokerintegration.ping', methods: ['GET'])]
+    public function ping(): Response
+    {
+        return new Response('BrokerIntegration OK');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/src/Infrastructure/Event/BrokerIntegrationSubscriber.php
+++ b/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/src/Infrastructure/Event/BrokerIntegrationSubscriber.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\BrokerIntegration\Infrastructure\Event;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class BrokerIntegrationSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // Shopware/Core events hier eintragen
+        ];
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/src/Resources/app/administration/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/src/Resources/app/administration/src/main.js
@@ -1,0 +1,1 @@
+import './module'; // extend administration here

--- a/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/src/Resources/app/storefront/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/src/Resources/app/storefront/src/main.js
@@ -1,0 +1,1 @@
+// storefront enhancements here

--- a/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/src/Resources/config/config.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/src/Resources/config/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/System/SystemConfig/Schema/config.xsd">
+  <card>
+    <title>BrokerIntegration Settings</title>
+    <input-field type="text" name="brokerintegration.example" label="Example setting"/>
+  </card>
+</config>

--- a/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/src/Resources/config/services.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/src/Resources/config/services.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+           https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="Acme\Csp\BrokerIntegration\Domain\Service\BrokerIntegrationFacade" public="true">
+      <argument type="service" id="logger"/>
+    </service>
+
+    <service id="Acme\Csp\BrokerIntegration\Infrastructure\Api\BrokerIntegrationPingController" public="true">
+      <tag name="controller.service_arguments"/>
+    </service>
+
+    <service id="Acme\Csp\BrokerIntegration\Infrastructure\Event\BrokerIntegrationSubscriber">
+      <tag name="kernel.event_subscriber"/>
+    </service>
+  </services>
+</container>

--- a/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/tests/ExampleTest.php
+++ b/AcmeCsp-Shopware-Stack/plugins/BrokerIntegration/tests/ExampleTest.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class ExampleTest extends TestCase
+{
+    public function testScaffold(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/CostCenters/README.md
+++ b/AcmeCsp-Shopware-Stack/plugins/CostCenters/README.md
@@ -1,0 +1,13 @@
+# CostCenters (Shopware Plugin)
+
+Problemstellung (allgemein):
+B2B/Public-Sector Portale benötigen Governance/Compliance/Integrationen, die Shopware OOTB nicht vollständig liefert.
+
+Ziel:
+Grundgerüst (Domain/DI/Events/API) zur schnellen Ergänzung projektspezifischer Business-Logik.
+
+Best Practices:
+- Keine Core-Hacks; Events/Subscriber/Decorators verwenden.
+- DAL statt direkter SQL-Zugriffe (außer Migrationen).
+- System-Config/Policies dokumentieren.
+- Unit/Integration-Tests früh anlegen.

--- a/AcmeCsp-Shopware-Stack/plugins/CostCenters/composer.json
+++ b/AcmeCsp-Shopware-Stack/plugins/CostCenters/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "acme/shopware-costcenters",
+  "type": "shopware-platform-plugin",
+  "description": "CostCenters plugin scaffold",
+  "license": "proprietary",
+  "require": {
+    "php": ">=8.1",
+    "shopware/core": "^6.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "Acme\\Csp\\CostCenters\": "src/"
+    }
+  },
+  "extra": {
+    "shopware-plugin-class": "Acme\\Csp\\CostCenters\CostCenters",
+    "label": "CostCenters (Scaffold)"
+  }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/CostCenters/phpunit.xml.dist
+++ b/AcmeCsp-Shopware-Stack/plugins/CostCenters/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/Core/Content/CostCenter/CostCenterCollection.php
+++ b/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/Core/Content/CostCenter/CostCenterCollection.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\CostCenters\Core\Content\CostCenter;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+
+/**
+ * @method void add(CostCenterEntity $entity)
+ * @method void set(string $key, CostCenterEntity $entity)
+ * @method CostCenterEntity[] getIterator()
+ * @method CostCenterEntity[] getElements()
+ * @method CostCenterEntity|null get(string $key)
+ * @method CostCenterEntity|null first()
+ * @method CostCenterEntity|null last()
+ */
+class CostCenterCollection extends EntityCollection
+{
+    protected function getExpectedClass(): string
+    {
+        return CostCenterEntity::class;
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/Core/Content/CostCenter/CostCenterDefinition.php
+++ b/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/Core/Content/CostCenter/CostCenterDefinition.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\CostCenters\Core\Content\CostCenter;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Collection\FieldCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+
+final class CostCenterDefinition extends EntityDefinition
+{
+    public const ENTITY_NAME = 'acme_csp_cost_center';
+
+    public function getEntityName(): string { return self::ENTITY_NAME; }
+    public function getEntityClass(): string { return CostCenterEntity::class; }
+    public function getCollectionClass(): string { return CostCenterCollection::class; }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new Required(), new PrimaryKey()),
+            (new StringField('code', 'code'))->addFlags(new Required()),
+            new StringField('name', 'name'),
+        ]);
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/Core/Content/CostCenter/CostCenterEntity.php
+++ b/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/Core/Content/CostCenter/CostCenterEntity.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\CostCenters\Core\Content\CostCenter;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
+
+class CostCenterEntity extends Entity
+{
+    use EntityIdTrait;
+
+    protected string $code;
+    protected ?string $name = null;
+
+    public function getCode(): string { return $this->code; }
+    public function setCode(string $v): void { $this->code = $v; }
+
+    public function getName(): ?string { return $this->name; }
+    public function setName(?string $v): void { $this->name = $v; }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/CostCenters.php
+++ b/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/CostCenters.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\CostCenters;
+
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\Context\InstallContext;
+
+final class CostCenters extends Plugin
+{
+    public function install(InstallContext $installContext): void
+    {
+        parent::install($installContext);
+        // TODO: migrations, system config, ACL seeds
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/Domain/Service/CostCentersFacade.php
+++ b/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/Domain/Service/CostCentersFacade.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\CostCenters\Domain\Service;
+
+use Psr\Log\LoggerInterface;
+
+final class CostCentersFacade
+{
+    public function __construct(private readonly LoggerInterface $logger) {}
+
+    public function demo(): void
+    {
+        $this->logger->info('CostCenters: scaffold operational');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/Infrastructure/Api/CostCentersPingController.php
+++ b/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/Infrastructure/Api/CostCentersPingController.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\CostCenters\Infrastructure\Api;
+
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Route(defaults: ['_routeScope' => ['storefront']])]
+final class CostCentersPingController
+{
+    #[Route(path: '/api/costcenters/ping', name: 'costcenters.ping', methods: ['GET'])]
+    public function ping(): Response
+    {
+        return new Response('CostCenters OK');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/Infrastructure/Event/CostCentersSubscriber.php
+++ b/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/Infrastructure/Event/CostCentersSubscriber.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\CostCenters\Infrastructure\Event;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class CostCentersSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // Shopware/Core events hier eintragen
+        ];
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/Migration/Migration1700000000CreateCostCenter.php
+++ b/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/Migration/Migration1700000000CreateCostCenter.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\CostCenters\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1700000000CreateCostCenter extends MigrationStep
+{
+    public function getCreationTimestamp(): int { return 1700000000; }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement('
+            CREATE TABLE IF NOT EXISTS `acme_csp_cost_center` (
+                `id` BINARY(16) NOT NULL,
+                `code` VARCHAR(64) NOT NULL,
+                `name` VARCHAR(255) NULL,
+                `created_at` DATETIME(3) NOT NULL,
+                `updated_at` DATETIME(3) NULL,
+                PRIMARY KEY (`id`),
+                UNIQUE KEY `uniq_cost_center_code` (`code`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        ');
+    }
+
+    public function updateDestructive(Connection $connection): void {}
+}

--- a/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/Resources/app/administration/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/Resources/app/administration/src/main.js
@@ -1,0 +1,1 @@
+import './module'; // extend administration here

--- a/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/Resources/app/storefront/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/Resources/app/storefront/src/main.js
@@ -1,0 +1,1 @@
+// storefront enhancements here

--- a/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/Resources/config/config.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/Resources/config/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/System/SystemConfig/Schema/config.xsd">
+  <card>
+    <title>CostCenters Settings</title>
+    <input-field type="text" name="costcenters.example" label="Example setting"/>
+  </card>
+</config>

--- a/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/Resources/config/services.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/CostCenters/src/Resources/config/services.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+           https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="Acme\Csp\CostCenters\Domain\Service\CostCentersFacade" public="true">
+      <argument type="service" id="logger"/>
+    </service>
+
+    <service id="Acme\Csp\CostCenters\Infrastructure\Api\CostCentersPingController" public="true">
+      <tag name="controller.service_arguments"/>
+    </service>
+
+    <service id="Acme\Csp\CostCenters\Infrastructure\Event\CostCentersSubscriber">
+      <tag name="kernel.event_subscriber"/>
+    </service>
+  </services>
+</container>

--- a/AcmeCsp-Shopware-Stack/plugins/CostCenters/tests/ExampleTest.php
+++ b/AcmeCsp-Shopware-Stack/plugins/CostCenters/tests/ExampleTest.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class ExampleTest extends TestCase
+{
+    public function testScaffold(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/CustomForms/README.md
+++ b/AcmeCsp-Shopware-Stack/plugins/CustomForms/README.md
@@ -1,0 +1,13 @@
+# CustomForms (Shopware Plugin)
+
+Problemstellung (allgemein):
+B2B/Public-Sector Portale benötigen Governance/Compliance/Integrationen, die Shopware OOTB nicht vollständig liefert.
+
+Ziel:
+Grundgerüst (Domain/DI/Events/API) zur schnellen Ergänzung projektspezifischer Business-Logik.
+
+Best Practices:
+- Keine Core-Hacks; Events/Subscriber/Decorators verwenden.
+- DAL statt direkter SQL-Zugriffe (außer Migrationen).
+- System-Config/Policies dokumentieren.
+- Unit/Integration-Tests früh anlegen.

--- a/AcmeCsp-Shopware-Stack/plugins/CustomForms/composer.json
+++ b/AcmeCsp-Shopware-Stack/plugins/CustomForms/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "acme/shopware-customforms",
+  "type": "shopware-platform-plugin",
+  "description": "CustomForms plugin scaffold",
+  "license": "proprietary",
+  "require": {
+    "php": ">=8.1",
+    "shopware/core": "^6.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "Acme\\Csp\\CustomForms\": "src/"
+    }
+  },
+  "extra": {
+    "shopware-plugin-class": "Acme\\Csp\\CustomForms\CustomForms",
+    "label": "CustomForms (Scaffold)"
+  }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/CustomForms/phpunit.xml.dist
+++ b/AcmeCsp-Shopware-Stack/plugins/CustomForms/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/AcmeCsp-Shopware-Stack/plugins/CustomForms/src/CustomForms.php
+++ b/AcmeCsp-Shopware-Stack/plugins/CustomForms/src/CustomForms.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\CustomForms;
+
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\Context\InstallContext;
+
+final class CustomForms extends Plugin
+{
+    public function install(InstallContext $installContext): void
+    {
+        parent::install($installContext);
+        // TODO: migrations, system config, ACL seeds
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/CustomForms/src/Domain/Service/CustomFormsFacade.php
+++ b/AcmeCsp-Shopware-Stack/plugins/CustomForms/src/Domain/Service/CustomFormsFacade.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\CustomForms\Domain\Service;
+
+use Psr\Log\LoggerInterface;
+
+final class CustomFormsFacade
+{
+    public function __construct(private readonly LoggerInterface $logger) {}
+
+    public function demo(): void
+    {
+        $this->logger->info('CustomForms: scaffold operational');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/CustomForms/src/Infrastructure/Api/CustomFormsPingController.php
+++ b/AcmeCsp-Shopware-Stack/plugins/CustomForms/src/Infrastructure/Api/CustomFormsPingController.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\CustomForms\Infrastructure\Api;
+
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Route(defaults: ['_routeScope' => ['storefront']])]
+final class CustomFormsPingController
+{
+    #[Route(path: '/api/customforms/ping', name: 'customforms.ping', methods: ['GET'])]
+    public function ping(): Response
+    {
+        return new Response('CustomForms OK');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/CustomForms/src/Infrastructure/Event/CustomFormsSubscriber.php
+++ b/AcmeCsp-Shopware-Stack/plugins/CustomForms/src/Infrastructure/Event/CustomFormsSubscriber.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\CustomForms\Infrastructure\Event;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class CustomFormsSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // Shopware/Core events hier eintragen
+        ];
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/CustomForms/src/Resources/app/administration/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/CustomForms/src/Resources/app/administration/src/main.js
@@ -1,0 +1,1 @@
+import './module'; // extend administration here

--- a/AcmeCsp-Shopware-Stack/plugins/CustomForms/src/Resources/app/storefront/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/CustomForms/src/Resources/app/storefront/src/main.js
@@ -1,0 +1,1 @@
+// storefront enhancements here

--- a/AcmeCsp-Shopware-Stack/plugins/CustomForms/src/Resources/config/config.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/CustomForms/src/Resources/config/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/System/SystemConfig/Schema/config.xsd">
+  <card>
+    <title>CustomForms Settings</title>
+    <input-field type="text" name="customforms.example" label="Example setting"/>
+  </card>
+</config>

--- a/AcmeCsp-Shopware-Stack/plugins/CustomForms/src/Resources/config/services.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/CustomForms/src/Resources/config/services.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+           https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="Acme\Csp\CustomForms\Domain\Service\CustomFormsFacade" public="true">
+      <argument type="service" id="logger"/>
+    </service>
+
+    <service id="Acme\Csp\CustomForms\Infrastructure\Api\CustomFormsPingController" public="true">
+      <tag name="controller.service_arguments"/>
+    </service>
+
+    <service id="Acme\Csp\CustomForms\Infrastructure\Event\CustomFormsSubscriber">
+      <tag name="kernel.event_subscriber"/>
+    </service>
+  </services>
+</container>

--- a/AcmeCsp-Shopware-Stack/plugins/CustomForms/tests/ExampleTest.php
+++ b/AcmeCsp-Shopware-Stack/plugins/CustomForms/tests/ExampleTest.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class ExampleTest extends TestCase
+{
+    public function testScaffold(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/DrBackup/README.md
+++ b/AcmeCsp-Shopware-Stack/plugins/DrBackup/README.md
@@ -1,0 +1,13 @@
+# DrBackup (Shopware Plugin)
+
+Problemstellung (allgemein):
+B2B/Public-Sector Portale benötigen Governance/Compliance/Integrationen, die Shopware OOTB nicht vollständig liefert.
+
+Ziel:
+Grundgerüst (Domain/DI/Events/API) zur schnellen Ergänzung projektspezifischer Business-Logik.
+
+Best Practices:
+- Keine Core-Hacks; Events/Subscriber/Decorators verwenden.
+- DAL statt direkter SQL-Zugriffe (außer Migrationen).
+- System-Config/Policies dokumentieren.
+- Unit/Integration-Tests früh anlegen.

--- a/AcmeCsp-Shopware-Stack/plugins/DrBackup/composer.json
+++ b/AcmeCsp-Shopware-Stack/plugins/DrBackup/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "acme/shopware-drbackup",
+  "type": "shopware-platform-plugin",
+  "description": "DrBackup plugin scaffold",
+  "license": "proprietary",
+  "require": {
+    "php": ">=8.1",
+    "shopware/core": "^6.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "Acme\\Csp\\DrBackup\": "src/"
+    }
+  },
+  "extra": {
+    "shopware-plugin-class": "Acme\\Csp\\DrBackup\DrBackup",
+    "label": "DrBackup (Scaffold)"
+  }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/DrBackup/phpunit.xml.dist
+++ b/AcmeCsp-Shopware-Stack/plugins/DrBackup/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/AcmeCsp-Shopware-Stack/plugins/DrBackup/src/Domain/Service/DrBackupFacade.php
+++ b/AcmeCsp-Shopware-Stack/plugins/DrBackup/src/Domain/Service/DrBackupFacade.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\DrBackup\Domain\Service;
+
+use Psr\Log\LoggerInterface;
+
+final class DrBackupFacade
+{
+    public function __construct(private readonly LoggerInterface $logger) {}
+
+    public function demo(): void
+    {
+        $this->logger->info('DrBackup: scaffold operational');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/DrBackup/src/DrBackup.php
+++ b/AcmeCsp-Shopware-Stack/plugins/DrBackup/src/DrBackup.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\DrBackup;
+
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\Context\InstallContext;
+
+final class DrBackup extends Plugin
+{
+    public function install(InstallContext $installContext): void
+    {
+        parent::install($installContext);
+        // TODO: migrations, system config, ACL seeds
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/DrBackup/src/Infrastructure/Api/DrBackupPingController.php
+++ b/AcmeCsp-Shopware-Stack/plugins/DrBackup/src/Infrastructure/Api/DrBackupPingController.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\DrBackup\Infrastructure\Api;
+
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Route(defaults: ['_routeScope' => ['storefront']])]
+final class DrBackupPingController
+{
+    #[Route(path: '/api/drbackup/ping', name: 'drbackup.ping', methods: ['GET'])]
+    public function ping(): Response
+    {
+        return new Response('DrBackup OK');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/DrBackup/src/Infrastructure/Event/DrBackupSubscriber.php
+++ b/AcmeCsp-Shopware-Stack/plugins/DrBackup/src/Infrastructure/Event/DrBackupSubscriber.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\DrBackup\Infrastructure\Event;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class DrBackupSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // Shopware/Core events hier eintragen
+        ];
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/DrBackup/src/Resources/app/administration/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/DrBackup/src/Resources/app/administration/src/main.js
@@ -1,0 +1,1 @@
+import './module'; // extend administration here

--- a/AcmeCsp-Shopware-Stack/plugins/DrBackup/src/Resources/app/storefront/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/DrBackup/src/Resources/app/storefront/src/main.js
@@ -1,0 +1,1 @@
+// storefront enhancements here

--- a/AcmeCsp-Shopware-Stack/plugins/DrBackup/src/Resources/config/config.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/DrBackup/src/Resources/config/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/System/SystemConfig/Schema/config.xsd">
+  <card>
+    <title>DrBackup Settings</title>
+    <input-field type="text" name="drbackup.example" label="Example setting"/>
+  </card>
+</config>

--- a/AcmeCsp-Shopware-Stack/plugins/DrBackup/src/Resources/config/services.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/DrBackup/src/Resources/config/services.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+           https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="Acme\Csp\DrBackup\Domain\Service\DrBackupFacade" public="true">
+      <argument type="service" id="logger"/>
+    </service>
+
+    <service id="Acme\Csp\DrBackup\Infrastructure\Api\DrBackupPingController" public="true">
+      <tag name="controller.service_arguments"/>
+    </service>
+
+    <service id="Acme\Csp\DrBackup\Infrastructure\Event\DrBackupSubscriber">
+      <tag name="kernel.event_subscriber"/>
+    </service>
+  </services>
+</container>

--- a/AcmeCsp-Shopware-Stack/plugins/DrBackup/tests/ExampleTest.php
+++ b/AcmeCsp-Shopware-Stack/plugins/DrBackup/tests/ExampleTest.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class ExampleTest extends TestCase
+{
+    public function testScaffold(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/README.md
+++ b/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/README.md
@@ -1,0 +1,13 @@
+# ErpIntegration (Shopware Plugin)
+
+Problemstellung (allgemein):
+B2B/Public-Sector Portale benötigen Governance/Compliance/Integrationen, die Shopware OOTB nicht vollständig liefert.
+
+Ziel:
+Grundgerüst (Domain/DI/Events/API) zur schnellen Ergänzung projektspezifischer Business-Logik.
+
+Best Practices:
+- Keine Core-Hacks; Events/Subscriber/Decorators verwenden.
+- DAL statt direkter SQL-Zugriffe (außer Migrationen).
+- System-Config/Policies dokumentieren.
+- Unit/Integration-Tests früh anlegen.

--- a/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/composer.json
+++ b/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "acme/shopware-erpintegration",
+  "type": "shopware-platform-plugin",
+  "description": "ErpIntegration plugin scaffold",
+  "license": "proprietary",
+  "require": {
+    "php": ">=8.1",
+    "shopware/core": "^6.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "Acme\\Csp\\ErpIntegration\": "src/"
+    }
+  },
+  "extra": {
+    "shopware-plugin-class": "Acme\\Csp\\ErpIntegration\ErpIntegration",
+    "label": "ErpIntegration (Scaffold)"
+  }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/phpunit.xml.dist
+++ b/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/src/Domain/Service/ErpIntegrationFacade.php
+++ b/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/src/Domain/Service/ErpIntegrationFacade.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\ErpIntegration\Domain\Service;
+
+use Psr\Log\LoggerInterface;
+
+final class ErpIntegrationFacade
+{
+    public function __construct(private readonly LoggerInterface $logger) {}
+
+    public function demo(): void
+    {
+        $this->logger->info('ErpIntegration: scaffold operational');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/src/ErpIntegration.php
+++ b/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/src/ErpIntegration.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\ErpIntegration;
+
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\Context\InstallContext;
+
+final class ErpIntegration extends Plugin
+{
+    public function install(InstallContext $installContext): void
+    {
+        parent::install($installContext);
+        // TODO: migrations, system config, ACL seeds
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/src/Infrastructure/Api/ErpIntegrationPingController.php
+++ b/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/src/Infrastructure/Api/ErpIntegrationPingController.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\ErpIntegration\Infrastructure\Api;
+
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Route(defaults: ['_routeScope' => ['storefront']])]
+final class ErpIntegrationPingController
+{
+    #[Route(path: '/api/erpintegration/ping', name: 'erpintegration.ping', methods: ['GET'])]
+    public function ping(): Response
+    {
+        return new Response('ErpIntegration OK');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/src/Infrastructure/Event/ErpIntegrationSubscriber.php
+++ b/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/src/Infrastructure/Event/ErpIntegrationSubscriber.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\ErpIntegration\Infrastructure\Event;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class ErpIntegrationSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // Shopware/Core events hier eintragen
+        ];
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/src/Resources/app/administration/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/src/Resources/app/administration/src/main.js
@@ -1,0 +1,1 @@
+import './module'; // extend administration here

--- a/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/src/Resources/app/storefront/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/src/Resources/app/storefront/src/main.js
@@ -1,0 +1,1 @@
+// storefront enhancements here

--- a/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/src/Resources/config/config.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/src/Resources/config/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/System/SystemConfig/Schema/config.xsd">
+  <card>
+    <title>ErpIntegration Settings</title>
+    <input-field type="text" name="erpintegration.example" label="Example setting"/>
+  </card>
+</config>

--- a/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/src/Resources/config/services.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/src/Resources/config/services.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+           https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="Acme\Csp\ErpIntegration\Domain\Service\ErpIntegrationFacade" public="true">
+      <argument type="service" id="logger"/>
+    </service>
+
+    <service id="Acme\Csp\ErpIntegration\Infrastructure\Api\ErpIntegrationPingController" public="true">
+      <tag name="controller.service_arguments"/>
+    </service>
+
+    <service id="Acme\Csp\ErpIntegration\Infrastructure\Event\ErpIntegrationSubscriber">
+      <tag name="kernel.event_subscriber"/>
+    </service>
+  </services>
+</container>

--- a/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/tests/ExampleTest.php
+++ b/AcmeCsp-Shopware-Stack/plugins/ErpIntegration/tests/ExampleTest.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class ExampleTest extends TestCase
+{
+    public function testScaffold(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/README.md
+++ b/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/README.md
@@ -1,0 +1,13 @@
+# InvoicingXRechnung (Shopware Plugin)
+
+Problemstellung (allgemein):
+B2B/Public-Sector Portale benötigen Governance/Compliance/Integrationen, die Shopware OOTB nicht vollständig liefert.
+
+Ziel:
+Grundgerüst (Domain/DI/Events/API) zur schnellen Ergänzung projektspezifischer Business-Logik.
+
+Best Practices:
+- Keine Core-Hacks; Events/Subscriber/Decorators verwenden.
+- DAL statt direkter SQL-Zugriffe (außer Migrationen).
+- System-Config/Policies dokumentieren.
+- Unit/Integration-Tests früh anlegen.

--- a/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/composer.json
+++ b/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "acme/shopware-invoicingxrechnung",
+  "type": "shopware-platform-plugin",
+  "description": "InvoicingXRechnung plugin scaffold",
+  "license": "proprietary",
+  "require": {
+    "php": ">=8.1",
+    "shopware/core": "^6.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "Acme\\Csp\\InvoicingXRechnung\": "src/"
+    }
+  },
+  "extra": {
+    "shopware-plugin-class": "Acme\\Csp\\InvoicingXRechnung\InvoicingXRechnung",
+    "label": "InvoicingXRechnung (Scaffold)"
+  }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/phpunit.xml.dist
+++ b/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/src/Domain/Service/InvoicingXRechnungFacade.php
+++ b/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/src/Domain/Service/InvoicingXRechnungFacade.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\InvoicingXRechnung\Domain\Service;
+
+use Psr\Log\LoggerInterface;
+
+final class InvoicingXRechnungFacade
+{
+    public function __construct(private readonly LoggerInterface $logger) {}
+
+    public function demo(): void
+    {
+        $this->logger->info('InvoicingXRechnung: scaffold operational');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/src/Infrastructure/Api/InvoicingXRechnungPingController.php
+++ b/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/src/Infrastructure/Api/InvoicingXRechnungPingController.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\InvoicingXRechnung\Infrastructure\Api;
+
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Route(defaults: ['_routeScope' => ['storefront']])]
+final class InvoicingXRechnungPingController
+{
+    #[Route(path: '/api/invoicingxrechnung/ping', name: 'invoicingxrechnung.ping', methods: ['GET'])]
+    public function ping(): Response
+    {
+        return new Response('InvoicingXRechnung OK');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/src/Infrastructure/Event/InvoicingXRechnungSubscriber.php
+++ b/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/src/Infrastructure/Event/InvoicingXRechnungSubscriber.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\InvoicingXRechnung\Infrastructure\Event;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class InvoicingXRechnungSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // Shopware/Core events hier eintragen
+        ];
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/src/InvoicingXRechnung.php
+++ b/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/src/InvoicingXRechnung.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\InvoicingXRechnung;
+
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\Context\InstallContext;
+
+final class InvoicingXRechnung extends Plugin
+{
+    public function install(InstallContext $installContext): void
+    {
+        parent::install($installContext);
+        // TODO: migrations, system config, ACL seeds
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/src/Resources/app/administration/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/src/Resources/app/administration/src/main.js
@@ -1,0 +1,1 @@
+import './module'; // extend administration here

--- a/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/src/Resources/app/storefront/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/src/Resources/app/storefront/src/main.js
@@ -1,0 +1,1 @@
+// storefront enhancements here

--- a/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/src/Resources/config/config.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/src/Resources/config/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/System/SystemConfig/Schema/config.xsd">
+  <card>
+    <title>InvoicingXRechnung Settings</title>
+    <input-field type="text" name="invoicingxrechnung.example" label="Example setting"/>
+  </card>
+</config>

--- a/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/src/Resources/config/services.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/src/Resources/config/services.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+           https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="Acme\Csp\InvoicingXRechnung\Domain\Service\InvoicingXRechnungFacade" public="true">
+      <argument type="service" id="logger"/>
+    </service>
+
+    <service id="Acme\Csp\InvoicingXRechnung\Infrastructure\Api\InvoicingXRechnungPingController" public="true">
+      <tag name="controller.service_arguments"/>
+    </service>
+
+    <service id="Acme\Csp\InvoicingXRechnung\Infrastructure\Event\InvoicingXRechnungSubscriber">
+      <tag name="kernel.event_subscriber"/>
+    </service>
+  </services>
+</container>

--- a/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/tests/ExampleTest.php
+++ b/AcmeCsp-Shopware-Stack/plugins/InvoicingXRechnung/tests/ExampleTest.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class ExampleTest extends TestCase
+{
+    public function testScaffold(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/MandateManagement/README.md
+++ b/AcmeCsp-Shopware-Stack/plugins/MandateManagement/README.md
@@ -1,0 +1,13 @@
+# MandateManagement (Shopware Plugin)
+
+Problemstellung (allgemein):
+B2B/Public-Sector Portale benötigen Governance/Compliance/Integrationen, die Shopware OOTB nicht vollständig liefert.
+
+Ziel:
+Grundgerüst (Domain/DI/Events/API) zur schnellen Ergänzung projektspezifischer Business-Logik.
+
+Best Practices:
+- Keine Core-Hacks; Events/Subscriber/Decorators verwenden.
+- DAL statt direkter SQL-Zugriffe (außer Migrationen).
+- System-Config/Policies dokumentieren.
+- Unit/Integration-Tests früh anlegen.

--- a/AcmeCsp-Shopware-Stack/plugins/MandateManagement/composer.json
+++ b/AcmeCsp-Shopware-Stack/plugins/MandateManagement/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "acme/shopware-mandatemanagement",
+  "type": "shopware-platform-plugin",
+  "description": "MandateManagement plugin scaffold",
+  "license": "proprietary",
+  "require": {
+    "php": ">=8.1",
+    "shopware/core": "^6.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "Acme\\Csp\\MandateManagement\": "src/"
+    }
+  },
+  "extra": {
+    "shopware-plugin-class": "Acme\\Csp\\MandateManagement\MandateManagement",
+    "label": "MandateManagement (Scaffold)"
+  }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/MandateManagement/phpunit.xml.dist
+++ b/AcmeCsp-Shopware-Stack/plugins/MandateManagement/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/AcmeCsp-Shopware-Stack/plugins/MandateManagement/src/Domain/Service/MandateManagementFacade.php
+++ b/AcmeCsp-Shopware-Stack/plugins/MandateManagement/src/Domain/Service/MandateManagementFacade.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\MandateManagement\Domain\Service;
+
+use Psr\Log\LoggerInterface;
+
+final class MandateManagementFacade
+{
+    public function __construct(private readonly LoggerInterface $logger) {}
+
+    public function demo(): void
+    {
+        $this->logger->info('MandateManagement: scaffold operational');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/MandateManagement/src/Infrastructure/Api/MandateManagementPingController.php
+++ b/AcmeCsp-Shopware-Stack/plugins/MandateManagement/src/Infrastructure/Api/MandateManagementPingController.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\MandateManagement\Infrastructure\Api;
+
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Route(defaults: ['_routeScope' => ['storefront']])]
+final class MandateManagementPingController
+{
+    #[Route(path: '/api/mandatemanagement/ping', name: 'mandatemanagement.ping', methods: ['GET'])]
+    public function ping(): Response
+    {
+        return new Response('MandateManagement OK');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/MandateManagement/src/Infrastructure/Event/MandateManagementSubscriber.php
+++ b/AcmeCsp-Shopware-Stack/plugins/MandateManagement/src/Infrastructure/Event/MandateManagementSubscriber.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\MandateManagement\Infrastructure\Event;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class MandateManagementSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // Shopware/Core events hier eintragen
+        ];
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/MandateManagement/src/MandateManagement.php
+++ b/AcmeCsp-Shopware-Stack/plugins/MandateManagement/src/MandateManagement.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\MandateManagement;
+
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\Context\InstallContext;
+
+final class MandateManagement extends Plugin
+{
+    public function install(InstallContext $installContext): void
+    {
+        parent::install($installContext);
+        // TODO: migrations, system config, ACL seeds
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/MandateManagement/src/Resources/app/administration/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/MandateManagement/src/Resources/app/administration/src/main.js
@@ -1,0 +1,1 @@
+import './module'; // extend administration here

--- a/AcmeCsp-Shopware-Stack/plugins/MandateManagement/src/Resources/app/storefront/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/MandateManagement/src/Resources/app/storefront/src/main.js
@@ -1,0 +1,1 @@
+// storefront enhancements here

--- a/AcmeCsp-Shopware-Stack/plugins/MandateManagement/src/Resources/config/config.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/MandateManagement/src/Resources/config/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/System/SystemConfig/Schema/config.xsd">
+  <card>
+    <title>MandateManagement Settings</title>
+    <input-field type="text" name="mandatemanagement.example" label="Example setting"/>
+  </card>
+</config>

--- a/AcmeCsp-Shopware-Stack/plugins/MandateManagement/src/Resources/config/services.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/MandateManagement/src/Resources/config/services.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+           https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="Acme\Csp\MandateManagement\Domain\Service\MandateManagementFacade" public="true">
+      <argument type="service" id="logger"/>
+    </service>
+
+    <service id="Acme\Csp\MandateManagement\Infrastructure\Api\MandateManagementPingController" public="true">
+      <tag name="controller.service_arguments"/>
+    </service>
+
+    <service id="Acme\Csp\MandateManagement\Infrastructure\Event\MandateManagementSubscriber">
+      <tag name="kernel.event_subscriber"/>
+    </service>
+  </services>
+</container>

--- a/AcmeCsp-Shopware-Stack/plugins/MandateManagement/tests/ExampleTest.php
+++ b/AcmeCsp-Shopware-Stack/plugins/MandateManagement/tests/ExampleTest.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class ExampleTest extends TestCase
+{
+    public function testScaffold(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/Monitoring/README.md
+++ b/AcmeCsp-Shopware-Stack/plugins/Monitoring/README.md
@@ -1,0 +1,13 @@
+# Monitoring (Shopware Plugin)
+
+Problemstellung (allgemein):
+B2B/Public-Sector Portale benötigen Governance/Compliance/Integrationen, die Shopware OOTB nicht vollständig liefert.
+
+Ziel:
+Grundgerüst (Domain/DI/Events/API) zur schnellen Ergänzung projektspezifischer Business-Logik.
+
+Best Practices:
+- Keine Core-Hacks; Events/Subscriber/Decorators verwenden.
+- DAL statt direkter SQL-Zugriffe (außer Migrationen).
+- System-Config/Policies dokumentieren.
+- Unit/Integration-Tests früh anlegen.

--- a/AcmeCsp-Shopware-Stack/plugins/Monitoring/composer.json
+++ b/AcmeCsp-Shopware-Stack/plugins/Monitoring/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "acme/shopware-monitoring",
+  "type": "shopware-platform-plugin",
+  "description": "Monitoring plugin scaffold",
+  "license": "proprietary",
+  "require": {
+    "php": ">=8.1",
+    "shopware/core": "^6.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "Acme\\Csp\\Monitoring\": "src/"
+    }
+  },
+  "extra": {
+    "shopware-plugin-class": "Acme\\Csp\\Monitoring\Monitoring",
+    "label": "Monitoring (Scaffold)"
+  }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/Monitoring/phpunit.xml.dist
+++ b/AcmeCsp-Shopware-Stack/plugins/Monitoring/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/AcmeCsp-Shopware-Stack/plugins/Monitoring/src/Domain/Service/MonitoringFacade.php
+++ b/AcmeCsp-Shopware-Stack/plugins/Monitoring/src/Domain/Service/MonitoringFacade.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\Monitoring\Domain\Service;
+
+use Psr\Log\LoggerInterface;
+
+final class MonitoringFacade
+{
+    public function __construct(private readonly LoggerInterface $logger) {}
+
+    public function demo(): void
+    {
+        $this->logger->info('Monitoring: scaffold operational');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/Monitoring/src/Infrastructure/Api/MonitoringPingController.php
+++ b/AcmeCsp-Shopware-Stack/plugins/Monitoring/src/Infrastructure/Api/MonitoringPingController.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\Monitoring\Infrastructure\Api;
+
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Route(defaults: ['_routeScope' => ['storefront']])]
+final class MonitoringPingController
+{
+    #[Route(path: '/api/monitoring/ping', name: 'monitoring.ping', methods: ['GET'])]
+    public function ping(): Response
+    {
+        return new Response('Monitoring OK');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/Monitoring/src/Infrastructure/Event/MonitoringSubscriber.php
+++ b/AcmeCsp-Shopware-Stack/plugins/Monitoring/src/Infrastructure/Event/MonitoringSubscriber.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\Monitoring\Infrastructure\Event;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class MonitoringSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // Shopware/Core events hier eintragen
+        ];
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/Monitoring/src/Monitoring.php
+++ b/AcmeCsp-Shopware-Stack/plugins/Monitoring/src/Monitoring.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\Monitoring;
+
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\Context\InstallContext;
+
+final class Monitoring extends Plugin
+{
+    public function install(InstallContext $installContext): void
+    {
+        parent::install($installContext);
+        // TODO: migrations, system config, ACL seeds
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/Monitoring/src/Resources/app/administration/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/Monitoring/src/Resources/app/administration/src/main.js
@@ -1,0 +1,1 @@
+import './module'; // extend administration here

--- a/AcmeCsp-Shopware-Stack/plugins/Monitoring/src/Resources/app/storefront/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/Monitoring/src/Resources/app/storefront/src/main.js
@@ -1,0 +1,1 @@
+// storefront enhancements here

--- a/AcmeCsp-Shopware-Stack/plugins/Monitoring/src/Resources/config/config.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/Monitoring/src/Resources/config/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/System/SystemConfig/Schema/config.xsd">
+  <card>
+    <title>Monitoring Settings</title>
+    <input-field type="text" name="monitoring.example" label="Example setting"/>
+  </card>
+</config>

--- a/AcmeCsp-Shopware-Stack/plugins/Monitoring/src/Resources/config/services.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/Monitoring/src/Resources/config/services.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+           https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="Acme\Csp\Monitoring\Domain\Service\MonitoringFacade" public="true">
+      <argument type="service" id="logger"/>
+    </service>
+
+    <service id="Acme\Csp\Monitoring\Infrastructure\Api\MonitoringPingController" public="true">
+      <tag name="controller.service_arguments"/>
+    </service>
+
+    <service id="Acme\Csp\Monitoring\Infrastructure\Event\MonitoringSubscriber">
+      <tag name="kernel.event_subscriber"/>
+    </service>
+  </services>
+</container>

--- a/AcmeCsp-Shopware-Stack/plugins/Monitoring/tests/ExampleTest.php
+++ b/AcmeCsp-Shopware-Stack/plugins/Monitoring/tests/ExampleTest.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class ExampleTest extends TestCase
+{
+    public function testScaffold(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/README.md
+++ b/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/README.md
@@ -1,0 +1,13 @@
+# RolesPermissions (Shopware Plugin)
+
+Problemstellung (allgemein):
+B2B/Public-Sector Portale benötigen Governance/Compliance/Integrationen, die Shopware OOTB nicht vollständig liefert.
+
+Ziel:
+Grundgerüst (Domain/DI/Events/API) zur schnellen Ergänzung projektspezifischer Business-Logik.
+
+Best Practices:
+- Keine Core-Hacks; Events/Subscriber/Decorators verwenden.
+- DAL statt direkter SQL-Zugriffe (außer Migrationen).
+- System-Config/Policies dokumentieren.
+- Unit/Integration-Tests früh anlegen.

--- a/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/composer.json
+++ b/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "acme/shopware-rolespermissions",
+  "type": "shopware-platform-plugin",
+  "description": "RolesPermissions plugin scaffold",
+  "license": "proprietary",
+  "require": {
+    "php": ">=8.1",
+    "shopware/core": "^6.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "Acme\\Csp\\RolesPermissions\": "src/"
+    }
+  },
+  "extra": {
+    "shopware-plugin-class": "Acme\\Csp\\RolesPermissions\RolesPermissions",
+    "label": "RolesPermissions (Scaffold)"
+  }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/phpunit.xml.dist
+++ b/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/src/Domain/Service/RolesPermissionsFacade.php
+++ b/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/src/Domain/Service/RolesPermissionsFacade.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\RolesPermissions\Domain\Service;
+
+use Psr\Log\LoggerInterface;
+
+final class RolesPermissionsFacade
+{
+    public function __construct(private readonly LoggerInterface $logger) {}
+
+    public function demo(): void
+    {
+        $this->logger->info('RolesPermissions: scaffold operational');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/src/Infrastructure/Api/RolesPermissionsPingController.php
+++ b/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/src/Infrastructure/Api/RolesPermissionsPingController.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\RolesPermissions\Infrastructure\Api;
+
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Route(defaults: ['_routeScope' => ['storefront']])]
+final class RolesPermissionsPingController
+{
+    #[Route(path: '/api/rolespermissions/ping', name: 'rolespermissions.ping', methods: ['GET'])]
+    public function ping(): Response
+    {
+        return new Response('RolesPermissions OK');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/src/Infrastructure/Event/RolesPermissionsSubscriber.php
+++ b/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/src/Infrastructure/Event/RolesPermissionsSubscriber.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\RolesPermissions\Infrastructure\Event;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class RolesPermissionsSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // Shopware/Core events hier eintragen
+        ];
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/src/Resources/app/administration/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/src/Resources/app/administration/src/main.js
@@ -1,0 +1,1 @@
+import './module'; // extend administration here

--- a/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/src/Resources/app/storefront/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/src/Resources/app/storefront/src/main.js
@@ -1,0 +1,1 @@
+// storefront enhancements here

--- a/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/src/Resources/config/config.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/src/Resources/config/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/System/SystemConfig/Schema/config.xsd">
+  <card>
+    <title>RolesPermissions Settings</title>
+    <input-field type="text" name="rolespermissions.example" label="Example setting"/>
+  </card>
+</config>

--- a/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/src/Resources/config/services.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/src/Resources/config/services.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+           https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="Acme\Csp\RolesPermissions\Domain\Service\RolesPermissionsFacade" public="true">
+      <argument type="service" id="logger"/>
+    </service>
+
+    <service id="Acme\Csp\RolesPermissions\Infrastructure\Api\RolesPermissionsPingController" public="true">
+      <tag name="controller.service_arguments"/>
+    </service>
+
+    <service id="Acme\Csp\RolesPermissions\Infrastructure\Event\RolesPermissionsSubscriber">
+      <tag name="kernel.event_subscriber"/>
+    </service>
+  </services>
+</container>

--- a/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/src/RolesPermissions.php
+++ b/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/src/RolesPermissions.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\RolesPermissions;
+
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\Context\InstallContext;
+
+final class RolesPermissions extends Plugin
+{
+    public function install(InstallContext $installContext): void
+    {
+        parent::install($installContext);
+        // TODO: migrations, system config, ACL seeds
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/tests/ExampleTest.php
+++ b/AcmeCsp-Shopware-Stack/plugins/RolesPermissions/tests/ExampleTest.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class ExampleTest extends TestCase
+{
+    public function testScaffold(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/SsoIdm/README.md
+++ b/AcmeCsp-Shopware-Stack/plugins/SsoIdm/README.md
@@ -1,0 +1,13 @@
+# SsoIdm (Shopware Plugin)
+
+Problemstellung (allgemein):
+B2B/Public-Sector Portale benötigen Governance/Compliance/Integrationen, die Shopware OOTB nicht vollständig liefert.
+
+Ziel:
+Grundgerüst (Domain/DI/Events/API) zur schnellen Ergänzung projektspezifischer Business-Logik.
+
+Best Practices:
+- Keine Core-Hacks; Events/Subscriber/Decorators verwenden.
+- DAL statt direkter SQL-Zugriffe (außer Migrationen).
+- System-Config/Policies dokumentieren.
+- Unit/Integration-Tests früh anlegen.

--- a/AcmeCsp-Shopware-Stack/plugins/SsoIdm/composer.json
+++ b/AcmeCsp-Shopware-Stack/plugins/SsoIdm/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "acme/shopware-ssoidm",
+  "type": "shopware-platform-plugin",
+  "description": "SsoIdm plugin scaffold",
+  "license": "proprietary",
+  "require": {
+    "php": ">=8.1",
+    "shopware/core": "^6.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "Acme\\Csp\\SsoIdm\": "src/"
+    }
+  },
+  "extra": {
+    "shopware-plugin-class": "Acme\\Csp\\SsoIdm\SsoIdm",
+    "label": "SsoIdm (Scaffold)"
+  }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/SsoIdm/phpunit.xml.dist
+++ b/AcmeCsp-Shopware-Stack/plugins/SsoIdm/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/AcmeCsp-Shopware-Stack/plugins/SsoIdm/src/Domain/Service/SsoIdmFacade.php
+++ b/AcmeCsp-Shopware-Stack/plugins/SsoIdm/src/Domain/Service/SsoIdmFacade.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\SsoIdm\Domain\Service;
+
+use Psr\Log\LoggerInterface;
+
+final class SsoIdmFacade
+{
+    public function __construct(private readonly LoggerInterface $logger) {}
+
+    public function demo(): void
+    {
+        $this->logger->info('SsoIdm: scaffold operational');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/SsoIdm/src/Infrastructure/Api/SsoIdmPingController.php
+++ b/AcmeCsp-Shopware-Stack/plugins/SsoIdm/src/Infrastructure/Api/SsoIdmPingController.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\SsoIdm\Infrastructure\Api;
+
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Route(defaults: ['_routeScope' => ['storefront']])]
+final class SsoIdmPingController
+{
+    #[Route(path: '/api/ssoidm/ping', name: 'ssoidm.ping', methods: ['GET'])]
+    public function ping(): Response
+    {
+        return new Response('SsoIdm OK');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/SsoIdm/src/Infrastructure/Event/SsoIdmSubscriber.php
+++ b/AcmeCsp-Shopware-Stack/plugins/SsoIdm/src/Infrastructure/Event/SsoIdmSubscriber.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\SsoIdm\Infrastructure\Event;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class SsoIdmSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // Shopware/Core events hier eintragen
+        ];
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/SsoIdm/src/Resources/app/administration/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/SsoIdm/src/Resources/app/administration/src/main.js
@@ -1,0 +1,1 @@
+import './module'; // extend administration here

--- a/AcmeCsp-Shopware-Stack/plugins/SsoIdm/src/Resources/app/storefront/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/SsoIdm/src/Resources/app/storefront/src/main.js
@@ -1,0 +1,1 @@
+// storefront enhancements here

--- a/AcmeCsp-Shopware-Stack/plugins/SsoIdm/src/Resources/config/config.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/SsoIdm/src/Resources/config/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/System/SystemConfig/Schema/config.xsd">
+  <card>
+    <title>SsoIdm Settings</title>
+    <input-field type="text" name="ssoidm.example" label="Example setting"/>
+  </card>
+</config>

--- a/AcmeCsp-Shopware-Stack/plugins/SsoIdm/src/Resources/config/services.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/SsoIdm/src/Resources/config/services.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+           https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="Acme\Csp\SsoIdm\Domain\Service\SsoIdmFacade" public="true">
+      <argument type="service" id="logger"/>
+    </service>
+
+    <service id="Acme\Csp\SsoIdm\Infrastructure\Api\SsoIdmPingController" public="true">
+      <tag name="controller.service_arguments"/>
+    </service>
+
+    <service id="Acme\Csp\SsoIdm\Infrastructure\Event\SsoIdmSubscriber">
+      <tag name="kernel.event_subscriber"/>
+    </service>
+  </services>
+</container>

--- a/AcmeCsp-Shopware-Stack/plugins/SsoIdm/src/SsoIdm.php
+++ b/AcmeCsp-Shopware-Stack/plugins/SsoIdm/src/SsoIdm.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\SsoIdm;
+
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\Context\InstallContext;
+
+final class SsoIdm extends Plugin
+{
+    public function install(InstallContext $installContext): void
+    {
+        parent::install($installContext);
+        // TODO: migrations, system config, ACL seeds
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/SsoIdm/tests/ExampleTest.php
+++ b/AcmeCsp-Shopware-Stack/plugins/SsoIdm/tests/ExampleTest.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class ExampleTest extends TestCase
+{
+    public function testScaffold(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/README.md
+++ b/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/README.md
@@ -1,0 +1,13 @@
+# ThemingBranding (Shopware Plugin)
+
+Problemstellung (allgemein):
+B2B/Public-Sector Portale benötigen Governance/Compliance/Integrationen, die Shopware OOTB nicht vollständig liefert.
+
+Ziel:
+Grundgerüst (Domain/DI/Events/API) zur schnellen Ergänzung projektspezifischer Business-Logik.
+
+Best Practices:
+- Keine Core-Hacks; Events/Subscriber/Decorators verwenden.
+- DAL statt direkter SQL-Zugriffe (außer Migrationen).
+- System-Config/Policies dokumentieren.
+- Unit/Integration-Tests früh anlegen.

--- a/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/composer.json
+++ b/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "acme/shopware-themingbranding",
+  "type": "shopware-platform-plugin",
+  "description": "ThemingBranding plugin scaffold",
+  "license": "proprietary",
+  "require": {
+    "php": ">=8.1",
+    "shopware/core": "^6.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "Acme\\Csp\\ThemingBranding\": "src/"
+    }
+  },
+  "extra": {
+    "shopware-plugin-class": "Acme\\Csp\\ThemingBranding\ThemingBranding",
+    "label": "ThemingBranding (Scaffold)"
+  }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/phpunit.xml.dist
+++ b/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/src/Domain/Service/ThemingBrandingFacade.php
+++ b/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/src/Domain/Service/ThemingBrandingFacade.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\ThemingBranding\Domain\Service;
+
+use Psr\Log\LoggerInterface;
+
+final class ThemingBrandingFacade
+{
+    public function __construct(private readonly LoggerInterface $logger) {}
+
+    public function demo(): void
+    {
+        $this->logger->info('ThemingBranding: scaffold operational');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/src/Infrastructure/Api/ThemingBrandingPingController.php
+++ b/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/src/Infrastructure/Api/ThemingBrandingPingController.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\ThemingBranding\Infrastructure\Api;
+
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Route(defaults: ['_routeScope' => ['storefront']])]
+final class ThemingBrandingPingController
+{
+    #[Route(path: '/api/themingbranding/ping', name: 'themingbranding.ping', methods: ['GET'])]
+    public function ping(): Response
+    {
+        return new Response('ThemingBranding OK');
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/src/Infrastructure/Event/ThemingBrandingSubscriber.php
+++ b/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/src/Infrastructure/Event/ThemingBrandingSubscriber.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\ThemingBranding\Infrastructure\Event;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class ThemingBrandingSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // Shopware/Core events hier eintragen
+        ];
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/src/Resources/app/administration/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/src/Resources/app/administration/src/main.js
@@ -1,0 +1,1 @@
+import './module'; // extend administration here

--- a/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/src/Resources/app/storefront/src/main.js
+++ b/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/src/Resources/app/storefront/src/main.js
@@ -1,0 +1,1 @@
+// storefront enhancements here

--- a/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/src/Resources/config/config.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/src/Resources/config/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/System/SystemConfig/Schema/config.xsd">
+  <card>
+    <title>ThemingBranding Settings</title>
+    <input-field type="text" name="themingbranding.example" label="Example setting"/>
+  </card>
+</config>

--- a/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/src/Resources/config/services.xml
+++ b/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/src/Resources/config/services.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+           https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="Acme\Csp\ThemingBranding\Domain\Service\ThemingBrandingFacade" public="true">
+      <argument type="service" id="logger"/>
+    </service>
+
+    <service id="Acme\Csp\ThemingBranding\Infrastructure\Api\ThemingBrandingPingController" public="true">
+      <tag name="controller.service_arguments"/>
+    </service>
+
+    <service id="Acme\Csp\ThemingBranding\Infrastructure\Event\ThemingBrandingSubscriber">
+      <tag name="kernel.event_subscriber"/>
+    </service>
+  </services>
+</container>

--- a/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/src/ThemingBranding.php
+++ b/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/src/ThemingBranding.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\Csp\ThemingBranding;
+
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\Context\InstallContext;
+
+final class ThemingBranding extends Plugin
+{
+    public function install(InstallContext $installContext): void
+    {
+        parent::install($installContext);
+        // TODO: migrations, system config, ACL seeds
+    }
+}

--- a/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/tests/ExampleTest.php
+++ b/AcmeCsp-Shopware-Stack/plugins/ThemingBranding/tests/ExampleTest.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class ExampleTest extends TestCase
+{
+    public function testScaffold(): void
+    {
+        self::assertTrue(true);
+    }
+}


### PR DESCRIPTION
## Summary
- generate the Acme/Csp Shopware stack skeleton with top-level documentation and tooling defaults
- scaffold the listed governance, finance, integration, and compliance plugins with PSR-4 namespaces, service wiring, and test placeholders
- add initial DAL entities for cost centers and approval workflow approval steps to anchor future business logic

## Testing
- not run (not requested)
