### PR TITLE
Add Randnotizen knowledge base scaffold

### DIFF
--- a/Randnotizen/Accessibility.md
+++ b/Randnotizen/Accessibility.md
@@ -1,0 +1,29 @@
+# Accessibility (WCAG/BITV)
+
+## Kundenanforderung (einfach)
+<Kurz in Klartext: Was will der Kunde in diesem Bereich erreichen?>
+
+## Warum ist das so?
+<Kontext: fachlich/organisatorisch/rechtlich – worin liegt der Bedarf?>
+
+## Besonderheiten im B2G
+<Was macht es in Behördenprojekten strenger/anders?>
+
+## Was fehlt in Shopware OOTB?
+<Kernlücken gegenüber dem Standard; warum braucht es ein Modul/Plugin?>
+
+## Technische Umsetzung (Allgemein)
+<Architektur-Muster, Datenmodell, Prozesse, Zustände, Benachrichtigungen, Validierungen>
+
+## Spezifische Anforderungen an Shopware
+<SW6: DAL, Events, Admin/Storefront-Erweiterungen, Rule/Flow-Builder, System-Config, Migrations …>
+
+## Abhängigkeiten / Überschneidungen
+<Bezug zu anderen Modulen: wer triggert wen, in welcher Reihenfolge?>
+
+## Checkliste
+- [ ] Anforderungen fachlich dokumentiert
+- [ ] Datenmodell & Migrations definiert
+- [ ] Admin-UI/Storefront-UX skizziert
+- [ ] Events/Integrationen (in/out) festgelegt
+- [ ] Tests/Monitoring/Audit berücksichtigt

--- a/Randnotizen/ApprovalWorkflow.md
+++ b/Randnotizen/ApprovalWorkflow.md
@@ -1,0 +1,29 @@
+# Approval Workflow (Genehmigungen & Eskalationen)
+
+## Kundenanforderung (einfach)
+<Kurz in Klartext: Was will der Kunde in diesem Bereich erreichen?>
+
+## Warum ist das so?
+<Kontext: fachlich/organisatorisch/rechtlich – worin liegt der Bedarf?>
+
+## Besonderheiten im B2G
+<Was macht es in Behördenprojekten strenger/anders?>
+
+## Was fehlt in Shopware OOTB?
+<Kernlücken gegenüber dem Standard; warum braucht es ein Modul/Plugin?>
+
+## Technische Umsetzung (Allgemein)
+<Architektur-Muster, Datenmodell, Prozesse, Zustände, Benachrichtigungen, Validierungen>
+
+## Spezifische Anforderungen an Shopware
+<SW6: DAL, Events, Admin/Storefront-Erweiterungen, Rule/Flow-Builder, System-Config, Migrations …>
+
+## Abhängigkeiten / Überschneidungen
+<Bezug zu anderen Modulen: wer triggert wen, in welcher Reihenfolge?>
+
+## Checkliste
+- [ ] Anforderungen fachlich dokumentiert
+- [ ] Datenmodell & Migrations definiert
+- [ ] Admin-UI/Storefront-UX skizziert
+- [ ] Events/Integrationen (in/out) festgelegt
+- [ ] Tests/Monitoring/Audit berücksichtigt

--- a/Randnotizen/AuditLogging.md
+++ b/Randnotizen/AuditLogging.md
@@ -1,0 +1,29 @@
+# Audit Logging (Revisionssicherheit)
+
+## Kundenanforderung (einfach)
+<Kurz in Klartext: Was will der Kunde in diesem Bereich erreichen?>
+
+## Warum ist das so?
+<Kontext: fachlich/organisatorisch/rechtlich – worin liegt der Bedarf?>
+
+## Besonderheiten im B2G
+<Was macht es in Behördenprojekten strenger/anders?>
+
+## Was fehlt in Shopware OOTB?
+<Kernlücken gegenüber dem Standard; warum braucht es ein Modul/Plugin?>
+
+## Technische Umsetzung (Allgemein)
+<Architektur-Muster, Datenmodell, Prozesse, Zustände, Benachrichtigungen, Validierungen>
+
+## Spezifische Anforderungen an Shopware
+<SW6: DAL, Events, Admin/Storefront-Erweiterungen, Rule/Flow-Builder, System-Config, Migrations …>
+
+## Abhängigkeiten / Überschneidungen
+<Bezug zu anderen Modulen: wer triggert wen, in welcher Reihenfolge?>
+
+## Checkliste
+- [ ] Anforderungen fachlich dokumentiert
+- [ ] Datenmodell & Migrations definiert
+- [ ] Admin-UI/Storefront-UX skizziert
+- [ ] Events/Integrationen (in/out) festgelegt
+- [ ] Tests/Monitoring/Audit berücksichtigt

--- a/Randnotizen/B2G_Besonderheiten.md
+++ b/Randnotizen/B2G_Besonderheiten.md
@@ -1,0 +1,26 @@
+# B2G – Besonderheiten (Allgemein)
+
+## Kundenanforderung (einfach)
+Beschaffungs-/Service-Portale für Behörden müssen **rechtskonform, nachvollziehbar, barrierefrei, mandantenfähig** und **prüfbar** betrieben werden.
+
+## Warum ist das so?
+Öffentliche Mittel, Vergabe-/Haushaltsrecht, Prüfbarkeit (Rechnungshof/Revision), Transparenzpflicht, Dokumentations- und Archivierungspflichten.
+
+## Besonderheiten im B2G
+- **Vergabe/Ausschreibung**: definierte Prozesse, Schwellenwerte, Nachweise.
+- **Compliance**: DSGVO, Informationssicherheit (BSI-Vorgaben), Protokollierung.
+- **Barrierefreiheit**: WCAG/BITV verbindlich.
+- **E-Rechnung**: XRechnung/ZUGFeRD, Leitweg-ID etc.
+- **Mandanten/Organisationen**: Hierarchien, Rollen, Budgetstellen.
+- **Identität/SSO**: Föderierte Logins, zentrale IDM-Vorgaben.
+- **Lifecycle & Nachweis**: Versionierung, Freigaben, Audit-Trails.
+
+## Was bedeutet das für die technische Umsetzung?
+- Feingranulare **Rollen/Workflows**; strikte **Mandantentrennung**.
+- **Sichere AuthN/Z** (SAML/OIDC), **CSP/Hardening**, Logging.
+- **Erweiterte Datenmodelle** (Kostenstellen, Mandate, Genehmigungen).
+- **Integrationen/Standards** (PEPPOL/OCI/cXML/ERP/IDM).
+- **Automatisierte Tests & Doku** als Projektstandard.
+
+## Checkliste (kurz)
+- Rollen/Workflows geklärt? • Mandantenmodell? • E-Rechnung? • SSO/IDM? • WCAG? • Audit/Monitoring/Backup? • Externe Standards & Schnittstellen?

--- a/Randnotizen/B2G_Technische_Auswirkungen.md
+++ b/Randnotizen/B2G_Technische_Auswirkungen.md
@@ -1,0 +1,20 @@
+# B2G – Technische Auswirkungen
+
+## Architektur
+- **Policy-getrieben** (RBAC/ABAC), Events, asynchron (Queues), idempotente Integrationen.
+- **Mandantenfähigkeit** (Daten-/Sicht-/Budget-Trennung), Branding je Mandant.
+
+## Sicherheit/Compliance
+- **CSP**, TLS, Secrets-Management, Hardening.
+- **Audit-Trails** (unveränderbar), Aufbewahrung, Export.
+- **Privacy by Design** (Minimierung, Löschkonzepte).
+
+## Schnittstellen
+- **ERP** (Stammdaten/Order/Invoice), **Broker** (Punchout/PEPPOL), **IDM** (SAML/OIDC), **E-Rechnung** (XRechnung/ZUGFeRD).
+
+## Betrieb
+- **Monitoring/APM/Logs**, Alerting, **DR/Backup** (RPO/RTO).
+- **CI/CD**, Tests (Unit/Integrations/E2E), Doku/ADRs.
+
+## Shopware-Implikationen
+- OOTB reicht selten: **Plugins/Custom-Module** für Rollen, Approval, CostCenter, E-Invoice, SSO, Audit, etc.

--- a/Randnotizen/BrokerIntegration.md
+++ b/Randnotizen/BrokerIntegration.md
@@ -1,0 +1,29 @@
+# Broker/Procurement Integration (Punchout/OCI/cXML/PEPPOL)
+
+## Kundenanforderung (einfach)
+<Kurz in Klartext: Was will der Kunde in diesem Bereich erreichen?>
+
+## Warum ist das so?
+<Kontext: fachlich/organisatorisch/rechtlich – worin liegt der Bedarf?>
+
+## Besonderheiten im B2G
+<Was macht es in Behördenprojekten strenger/anders?>
+
+## Was fehlt in Shopware OOTB?
+<Kernlücken gegenüber dem Standard; warum braucht es ein Modul/Plugin?>
+
+## Technische Umsetzung (Allgemein)
+<Architektur-Muster, Datenmodell, Prozesse, Zustände, Benachrichtigungen, Validierungen>
+
+## Spezifische Anforderungen an Shopware
+<SW6: DAL, Events, Admin/Storefront-Erweiterungen, Rule/Flow-Builder, System-Config, Migrations …>
+
+## Abhängigkeiten / Überschneidungen
+<Bezug zu anderen Modulen: wer triggert wen, in welcher Reihenfolge?>
+
+## Checkliste
+- [ ] Anforderungen fachlich dokumentiert
+- [ ] Datenmodell & Migrations definiert
+- [ ] Admin-UI/Storefront-UX skizziert
+- [ ] Events/Integrationen (in/out) festgelegt
+- [ ] Tests/Monitoring/Audit berücksichtigt

--- a/Randnotizen/CostCenters.md
+++ b/Randnotizen/CostCenters.md
@@ -1,0 +1,29 @@
+# Cost Centers (Kontierung & Budgetkontrolle)
+
+## Kundenanforderung (einfach)
+<Kurz in Klartext: Was will der Kunde in diesem Bereich erreichen?>
+
+## Warum ist das so?
+<Kontext: fachlich/organisatorisch/rechtlich – worin liegt der Bedarf?>
+
+## Besonderheiten im B2G
+<Was macht es in Behördenprojekten strenger/anders?>
+
+## Was fehlt in Shopware OOTB?
+<Kernlücken gegenüber dem Standard; warum braucht es ein Modul/Plugin?>
+
+## Technische Umsetzung (Allgemein)
+<Architektur-Muster, Datenmodell, Prozesse, Zustände, Benachrichtigungen, Validierungen>
+
+## Spezifische Anforderungen an Shopware
+<SW6: DAL, Events, Admin/Storefront-Erweiterungen, Rule/Flow-Builder, System-Config, Migrations …>
+
+## Abhängigkeiten / Überschneidungen
+<Bezug zu anderen Modulen: wer triggert wen, in welcher Reihenfolge?>
+
+## Checkliste
+- [ ] Anforderungen fachlich dokumentiert
+- [ ] Datenmodell & Migrations definiert
+- [ ] Admin-UI/Storefront-UX skizziert
+- [ ] Events/Integrationen (in/out) festgelegt
+- [ ] Tests/Monitoring/Audit berücksichtigt

--- a/Randnotizen/CustomForms.md
+++ b/Randnotizen/CustomForms.md
@@ -1,0 +1,29 @@
+# Custom Forms (Form-Builder, Validierung, Übergaben)
+
+## Kundenanforderung (einfach)
+<Kurz in Klartext: Was will der Kunde in diesem Bereich erreichen?>
+
+## Warum ist das so?
+<Kontext: fachlich/organisatorisch/rechtlich – worin liegt der Bedarf?>
+
+## Besonderheiten im B2G
+<Was macht es in Behördenprojekten strenger/anders?>
+
+## Was fehlt in Shopware OOTB?
+<Kernlücken gegenüber dem Standard; warum braucht es ein Modul/Plugin?>
+
+## Technische Umsetzung (Allgemein)
+<Architektur-Muster, Datenmodell, Prozesse, Zustände, Benachrichtigungen, Validierungen>
+
+## Spezifische Anforderungen an Shopware
+<SW6: DAL, Events, Admin/Storefront-Erweiterungen, Rule/Flow-Builder, System-Config, Migrations …>
+
+## Abhängigkeiten / Überschneidungen
+<Bezug zu anderen Modulen: wer triggert wen, in welcher Reihenfolge?>
+
+## Checkliste
+- [ ] Anforderungen fachlich dokumentiert
+- [ ] Datenmodell & Migrations definiert
+- [ ] Admin-UI/Storefront-UX skizziert
+- [ ] Events/Integrationen (in/out) festgelegt
+- [ ] Tests/Monitoring/Audit berücksichtigt

--- a/Randnotizen/DrBackup.md
+++ b/Randnotizen/DrBackup.md
@@ -1,0 +1,29 @@
+# Disaster Recovery & Backup (RPO/RTO)
+
+## Kundenanforderung (einfach)
+<Kurz in Klartext: Was will der Kunde in diesem Bereich erreichen?>
+
+## Warum ist das so?
+<Kontext: fachlich/organisatorisch/rechtlich – worin liegt der Bedarf?>
+
+## Besonderheiten im B2G
+<Was macht es in Behördenprojekten strenger/anders?>
+
+## Was fehlt in Shopware OOTB?
+<Kernlücken gegenüber dem Standard; warum braucht es ein Modul/Plugin?>
+
+## Technische Umsetzung (Allgemein)
+<Architektur-Muster, Datenmodell, Prozesse, Zustände, Benachrichtigungen, Validierungen>
+
+## Spezifische Anforderungen an Shopware
+<SW6: DAL, Events, Admin/Storefront-Erweiterungen, Rule/Flow-Builder, System-Config, Migrations …>
+
+## Abhängigkeiten / Überschneidungen
+<Bezug zu anderen Modulen: wer triggert wen, in welcher Reihenfolge?>
+
+## Checkliste
+- [ ] Anforderungen fachlich dokumentiert
+- [ ] Datenmodell & Migrations definiert
+- [ ] Admin-UI/Storefront-UX skizziert
+- [ ] Events/Integrationen (in/out) festgelegt
+- [ ] Tests/Monitoring/Audit berücksichtigt

--- a/Randnotizen/ErpIntegration.md
+++ b/Randnotizen/ErpIntegration.md
@@ -1,0 +1,29 @@
+# ERP Integration (Stammdaten/Order/Preislogik)
+
+## Kundenanforderung (einfach)
+<Kurz in Klartext: Was will der Kunde in diesem Bereich erreichen?>
+
+## Warum ist das so?
+<Kontext: fachlich/organisatorisch/rechtlich – worin liegt der Bedarf?>
+
+## Besonderheiten im B2G
+<Was macht es in Behördenprojekten strenger/anders?>
+
+## Was fehlt in Shopware OOTB?
+<Kernlücken gegenüber dem Standard; warum braucht es ein Modul/Plugin?>
+
+## Technische Umsetzung (Allgemein)
+<Architektur-Muster, Datenmodell, Prozesse, Zustände, Benachrichtigungen, Validierungen>
+
+## Spezifische Anforderungen an Shopware
+<SW6: DAL, Events, Admin/Storefront-Erweiterungen, Rule/Flow-Builder, System-Config, Migrations …>
+
+## Abhängigkeiten / Überschneidungen
+<Bezug zu anderen Modulen: wer triggert wen, in welcher Reihenfolge?>
+
+## Checkliste
+- [ ] Anforderungen fachlich dokumentiert
+- [ ] Datenmodell & Migrations definiert
+- [ ] Admin-UI/Storefront-UX skizziert
+- [ ] Events/Integrationen (in/out) festgelegt
+- [ ] Tests/Monitoring/Audit berücksichtigt

--- a/Randnotizen/InvoicingXRechnung.md
+++ b/Randnotizen/InvoicingXRechnung.md
@@ -1,0 +1,29 @@
+# E-Invoicing (XRechnung/ZUGFeRD)
+
+## Kundenanforderung (einfach)
+<Kurz in Klartext: Was will der Kunde in diesem Bereich erreichen?>
+
+## Warum ist das so?
+<Kontext: fachlich/organisatorisch/rechtlich – worin liegt der Bedarf?>
+
+## Besonderheiten im B2G
+<Was macht es in Behördenprojekten strenger/anders?>
+
+## Was fehlt in Shopware OOTB?
+<Kernlücken gegenüber dem Standard; warum braucht es ein Modul/Plugin?>
+
+## Technische Umsetzung (Allgemein)
+<Architektur-Muster, Datenmodell, Prozesse, Zustände, Benachrichtigungen, Validierungen>
+
+## Spezifische Anforderungen an Shopware
+<SW6: DAL, Events, Admin/Storefront-Erweiterungen, Rule/Flow-Builder, System-Config, Migrations …>
+
+## Abhängigkeiten / Überschneidungen
+<Bezug zu anderen Modulen: wer triggert wen, in welcher Reihenfolge?>
+
+## Checkliste
+- [ ] Anforderungen fachlich dokumentiert
+- [ ] Datenmodell & Migrations definiert
+- [ ] Admin-UI/Storefront-UX skizziert
+- [ ] Events/Integrationen (in/out) festgelegt
+- [ ] Tests/Monitoring/Audit berücksichtigt

--- a/Randnotizen/MandateManagement.md
+++ b/Randnotizen/MandateManagement.md
@@ -1,0 +1,29 @@
+# Mandate Management (Bevollmächtigungen/Vertretungsrechte)
+
+## Kundenanforderung (einfach)
+<Kurz in Klartext: Was will der Kunde in diesem Bereich erreichen?>
+
+## Warum ist das so?
+<Kontext: fachlich/organisatorisch/rechtlich – worin liegt der Bedarf?>
+
+## Besonderheiten im B2G
+<Was macht es in Behördenprojekten strenger/anders?>
+
+## Was fehlt in Shopware OOTB?
+<Kernlücken gegenüber dem Standard; warum braucht es ein Modul/Plugin?>
+
+## Technische Umsetzung (Allgemein)
+<Architektur-Muster, Datenmodell, Prozesse, Zustände, Benachrichtigungen, Validierungen>
+
+## Spezifische Anforderungen an Shopware
+<SW6: DAL, Events, Admin/Storefront-Erweiterungen, Rule/Flow-Builder, System-Config, Migrations …>
+
+## Abhängigkeiten / Überschneidungen
+<Bezug zu anderen Modulen: wer triggert wen, in welcher Reihenfolge?>
+
+## Checkliste
+- [ ] Anforderungen fachlich dokumentiert
+- [ ] Datenmodell & Migrations definiert
+- [ ] Admin-UI/Storefront-UX skizziert
+- [ ] Events/Integrationen (in/out) festgelegt
+- [ ] Tests/Monitoring/Audit berücksichtigt

--- a/Randnotizen/Monitoring.md
+++ b/Randnotizen/Monitoring.md
@@ -1,0 +1,29 @@
+# Monitoring & Observability (Uptime/APM/Logs)
+
+## Kundenanforderung (einfach)
+<Kurz in Klartext: Was will der Kunde in diesem Bereich erreichen?>
+
+## Warum ist das so?
+<Kontext: fachlich/organisatorisch/rechtlich – worin liegt der Bedarf?>
+
+## Besonderheiten im B2G
+<Was macht es in Behördenprojekten strenger/anders?>
+
+## Was fehlt in Shopware OOTB?
+<Kernlücken gegenüber dem Standard; warum braucht es ein Modul/Plugin?>
+
+## Technische Umsetzung (Allgemein)
+<Architektur-Muster, Datenmodell, Prozesse, Zustände, Benachrichtigungen, Validierungen>
+
+## Spezifische Anforderungen an Shopware
+<SW6: DAL, Events, Admin/Storefront-Erweiterungen, Rule/Flow-Builder, System-Config, Migrations …>
+
+## Abhängigkeiten / Überschneidungen
+<Bezug zu anderen Modulen: wer triggert wen, in welcher Reihenfolge?>
+
+## Checkliste
+- [ ] Anforderungen fachlich dokumentiert
+- [ ] Datenmodell & Migrations definiert
+- [ ] Admin-UI/Storefront-UX skizziert
+- [ ] Events/Integrationen (in/out) festgelegt
+- [ ] Tests/Monitoring/Audit berücksichtigt

--- a/Randnotizen/README.md
+++ b/Randnotizen/README.md
@@ -1,0 +1,25 @@
+# Randnotizen – B2G & Shopware (Nachschlagewerk)
+
+Diese Sammlung bündelt die wichtigsten Problemstellungen und Lösungsansätze im **B2G**-Kontext (Behörden/öffentlicher Sektor) sowie deren **technische Auswirkungen** auf Shopware. Jede Seite ist kurz, prägnant und als Starthilfe für Implementierungen gedacht.
+
+## Allgemeiner Teil
+- [B2G_Besonderheiten](B2G_Besonderheiten.md) – Rechtliches/organisatorisches Umfeld, typische Prozesse, Pflichten.
+- [B2G_Technische_Auswirkungen](B2G_Technische_Auswirkungen.md) – Architektur- und Sicherheitsimplikationen, Standards, Muster.
+
+## Module (Shopware-spezifische Deep Dives)
+- [RolesPermissions](RolesPermissions.md) – Granulare Rollen & Berechtigungen, Unterkonten.
+- [MandateManagement](MandateManagement.md) – Vertretungsrechte/Bevollmächtigungen (Handeln im Namen der Organisation).
+- [ApprovalWorkflow](ApprovalWorkflow.md) – Mehrstufige Genehmigungen, Eskalation, Budgetgrenzen.
+- [CostCenters](CostCenters.md) – Kostenstellen, Kontierung, Budgetkontrolle & Reporting.
+- [InvoicingXRechnung](InvoicingXRechnung.md) – E-Rechnung/XRechnung/ZUGFeRD, Pflichtangaben, Validierung.
+- [BrokerIntegration](BrokerIntegration.md) – Punchout/OCI/cXML/PEPPOL, Kataloge & Bestellimport.
+- [ErpIntegration](ErpIntegration.md) – Stammdaten/Preise/Orders, Sync-Strategien, Fehlerrobustheit.
+- [SsoIdm](SsoIdm.md) – SAML/OIDC/LDAP, föderierte Logins, Rollen-Mapping.
+- [ThemingBranding](ThemingBranding.md) – Corporate Design/Behörden-CI, Multi-Branding je Mandant.
+- [Accessibility](Accessibility.md) – WCAG/BITV, Tests, Do/Don’t bei Themes & Plugins.
+- [CustomForms](CustomForms.md) – Form-Builder, Validierung, Persistenz, Übergabe an Fachverfahren.
+- [AuditLogging](AuditLogging.md) – Revisionssichere Protokolle, Scope, Aufbewahrung.
+- [Monitoring](Monitoring.md) – Uptime/APM/Logs/Security-Signale, Alarmierung, Berichte.
+- [DrBackup](DrBackup.md) – Backup/Restore, RPO/RTO, DR-Playbooks, Verschlüsselung.
+
+> Hinweis: Inhalte sind **kundengenerisch** formuliert (keine Namen). Jede Seite enthält: *Kundenanforderung*, *Warum (Kontext)*, *B2G-Besonderheiten*, *Was fehlt OOTB*, *Technische Umsetzung (Allgemein)*, *Spezifisch für Shopware*, *Abhängigkeiten/Überschneidungen*, *Checkliste*.

--- a/Randnotizen/RolesPermissions.md
+++ b/Randnotizen/RolesPermissions.md
@@ -1,0 +1,29 @@
+# Roles & Permissions (Rollen, Rechte, Unterkonten)
+
+## Kundenanforderung (einfach)
+<Kurz in Klartext: Was will der Kunde in diesem Bereich erreichen?>
+
+## Warum ist das so?
+<Kontext: fachlich/organisatorisch/rechtlich – worin liegt der Bedarf?>
+
+## Besonderheiten im B2G
+<Was macht es in Behördenprojekten strenger/anders?>
+
+## Was fehlt in Shopware OOTB?
+<Kernlücken gegenüber dem Standard; warum braucht es ein Modul/Plugin?>
+
+## Technische Umsetzung (Allgemein)
+<Architektur-Muster, Datenmodell, Prozesse, Zustände, Benachrichtigungen, Validierungen>
+
+## Spezifische Anforderungen an Shopware
+<SW6: DAL, Events, Admin/Storefront-Erweiterungen, Rule/Flow-Builder, System-Config, Migrations …>
+
+## Abhängigkeiten / Überschneidungen
+<Bezug zu anderen Modulen: wer triggert wen, in welcher Reihenfolge?>
+
+## Checkliste
+- [ ] Anforderungen fachlich dokumentiert
+- [ ] Datenmodell & Migrations definiert
+- [ ] Admin-UI/Storefront-UX skizziert
+- [ ] Events/Integrationen (in/out) festgelegt
+- [ ] Tests/Monitoring/Audit berücksichtigt

--- a/Randnotizen/SsoIdm.md
+++ b/Randnotizen/SsoIdm.md
@@ -1,0 +1,29 @@
+# SSO & IDM (SAML/OIDC/LDAP, Rollen-Mapping)
+
+## Kundenanforderung (einfach)
+<Kurz in Klartext: Was will der Kunde in diesem Bereich erreichen?>
+
+## Warum ist das so?
+<Kontext: fachlich/organisatorisch/rechtlich – worin liegt der Bedarf?>
+
+## Besonderheiten im B2G
+<Was macht es in Behördenprojekten strenger/anders?>
+
+## Was fehlt in Shopware OOTB?
+<Kernlücken gegenüber dem Standard; warum braucht es ein Modul/Plugin?>
+
+## Technische Umsetzung (Allgemein)
+<Architektur-Muster, Datenmodell, Prozesse, Zustände, Benachrichtigungen, Validierungen>
+
+## Spezifische Anforderungen an Shopware
+<SW6: DAL, Events, Admin/Storefront-Erweiterungen, Rule/Flow-Builder, System-Config, Migrations …>
+
+## Abhängigkeiten / Überschneidungen
+<Bezug zu anderen Modulen: wer triggert wen, in welcher Reihenfolge?>
+
+## Checkliste
+- [ ] Anforderungen fachlich dokumentiert
+- [ ] Datenmodell & Migrations definiert
+- [ ] Admin-UI/Storefront-UX skizziert
+- [ ] Events/Integrationen (in/out) festgelegt
+- [ ] Tests/Monitoring/Audit berücksichtigt

--- a/Randnotizen/ThemingBranding.md
+++ b/Randnotizen/ThemingBranding.md
@@ -1,0 +1,29 @@
+# Theming & Branding (CI, Multi-Branding)
+
+## Kundenanforderung (einfach)
+<Kurz in Klartext: Was will der Kunde in diesem Bereich erreichen?>
+
+## Warum ist das so?
+<Kontext: fachlich/organisatorisch/rechtlich – worin liegt der Bedarf?>
+
+## Besonderheiten im B2G
+<Was macht es in Behördenprojekten strenger/anders?>
+
+## Was fehlt in Shopware OOTB?
+<Kernlücken gegenüber dem Standard; warum braucht es ein Modul/Plugin?>
+
+## Technische Umsetzung (Allgemein)
+<Architektur-Muster, Datenmodell, Prozesse, Zustände, Benachrichtigungen, Validierungen>
+
+## Spezifische Anforderungen an Shopware
+<SW6: DAL, Events, Admin/Storefront-Erweiterungen, Rule/Flow-Builder, System-Config, Migrations …>
+
+## Abhängigkeiten / Überschneidungen
+<Bezug zu anderen Modulen: wer triggert wen, in welcher Reihenfolge?>
+
+## Checkliste
+- [ ] Anforderungen fachlich dokumentiert
+- [ ] Datenmodell & Migrations definiert
+- [ ] Admin-UI/Storefront-UX skizziert
+- [ ] Events/Integrationen (in/out) festgelegt
+- [ ] Tests/Monitoring/Audit berücksichtigt


### PR DESCRIPTION
## Summary
- add a Randnotizen knowledge base directory with an overview README
- scaffold topic templates for B2G requirements and Shopware modules

## Testing
- not run
