### PR TITLE
Add skeleton examples for B2G plugin suite

### DIFF
--- a/Beispiele/B2GAccessibilityToolkit/README.md
+++ b/Beispiele/B2GAccessibilityToolkit/README.md
@@ -1,0 +1,13 @@
+# B2GAccessibilityToolkit (Skeleton)
+A11y-Hilfen für Storefront/Custom-Module (Kontrast-/Fokus-Vars, Muster für Dialog/ARIA, QS-Hinweise, CI-Checklisten).
+
+## Scope
+- Hilfs-SCSS/JS, Beispiel-Komponenten als Referenz.
+- Developer-Guides/Checklisten für WCAG 2.1 AA / BITV 2.0.
+- Keine Automatisierung in CI hier (nur Hinweise, Muster und Doku).
+
+## @todo
+- [ ] SCSS-Variablen/Fokus-Stile (AA) bereitstellen
+- [ ] Muster: Accessible Modal/Dropdown/Alert (ARIA)
+- [ ] Redaktionsleitfaden (Alt-Texte, Tabellen, Linktexte)
+- [ ] Beispiel-Page mit Tastatur-Tour

--- a/Beispiele/B2GAccessibilityToolkit/composer.json
+++ b/Beispiele/B2GAccessibilityToolkit/composer.json
@@ -1,0 +1,21 @@
+{
+  "name": "b2g/accessibility-toolkit",
+  "description": "Skeleton: A11y-Hilfen für Shopware-Storefront/Module",
+  "type": "shopware-platform-plugin",
+  "license": "proprietary",
+  "autoload": {
+    "psr-4": {
+      "B2G\\AccessibilityToolkit\\": "src/"
+    }
+  },
+  "extra": {
+    "shopware-plugin-class": "B2G\\AccessibilityToolkit\\B2GAccessibilityToolkit",
+    "label": {
+      "en-GB": "B2G Accessibility Toolkit",
+      "de-DE": "B2G Accessibility Toolkit"
+    }
+  },
+  "require": {
+    "php": ">=8.1"
+  }
+}

--- a/Beispiele/B2GAccessibilityToolkit/docs/REFERENZEN.md
+++ b/Beispiele/B2GAccessibilityToolkit/docs/REFERENZEN.md
@@ -1,0 +1,1 @@
+- Siehe: ../../Randnotizen/Accessibility_Barrierefreiheit.md

--- a/Beispiele/B2GAccessibilityToolkit/src/B2GAccessibilityToolkit.php
+++ b/Beispiele/B2GAccessibilityToolkit/src/B2GAccessibilityToolkit.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace B2G\AccessibilityToolkit;
+
+use Shopware\Core\Framework\Plugin;
+
+final class B2GAccessibilityToolkit extends Plugin
+{
+    // @todo: optional: provide storefront resources (scss/js) and docs
+}

--- a/Beispiele/B2GApprovalWorkflow/README.md
+++ b/Beispiele/B2GApprovalWorkflow/README.md
@@ -1,0 +1,14 @@
+# B2GApprovalWorkflow (Skeleton)
+Mehrstufige Freigaben (AND/OR), Fristen/Eskalation, Kommentare, Historie.
+
+## Scope
+- Policy/Rule-Definitions (nur Struktur)
+- Event-/Status-Maschine (nur Stub)
+- Admin-UI-Platzhalter (Konzept)
+
+## @todo
+- [ ] Entitäten: ApprovalRule/Stage/Decision (nur Migrations-Stubs)
+- [ ] Events: REQUESTED, APPROVED, REJECTED, ESCALATED
+- [ ] Eskalationsservice (Timer/Queue, @todo)
+- [ ] Storefront/Admin UI: Stub-Views
+- [ ] Export nur nach APPROVED (Webhook/ERP-Gate Stub)

--- a/Beispiele/B2GApprovalWorkflow/composer.json
+++ b/Beispiele/B2GApprovalWorkflow/composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "b2g/approval-workflow",
+  "description": "Skeleton: Mehrstufige Freigaben für Bestellungen",
+  "type": "shopware-platform-plugin",
+  "autoload": { "psr-4": { "B2G\\ApprovalWorkflow\\": "src/" } },
+  "extra": { "shopware-plugin-class": "B2G\\ApprovalWorkflow\\B2GApprovalWorkflow" },
+  "require": { "php": ">=8.1" }
+}

--- a/Beispiele/B2GApprovalWorkflow/docs/REFERENZEN.md
+++ b/Beispiele/B2GApprovalWorkflow/docs/REFERENZEN.md
@@ -1,0 +1,1 @@
+- Siehe: ../../Randnotizen/Approval_Workflow.md

--- a/Beispiele/B2GApprovalWorkflow/src/B2GApprovalWorkflow.php
+++ b/Beispiele/B2GApprovalWorkflow/src/B2GApprovalWorkflow.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+namespace B2G\ApprovalWorkflow;
+
+use Shopware\Core\Framework\Plugin;
+
+final class B2GApprovalWorkflow extends Plugin
+{
+    // @todo: register rule entities, events, stubs
+}

--- a/Beispiele/B2GAuditLogging/README.md
+++ b/Beispiele/B2GAuditLogging/README.md
@@ -1,0 +1,13 @@
+# B2GAuditLogging (Skeleton)
+Revisionssichere Protokolle (Logins, Rollenänderungen, Bestellungen, Freigaben, Schnittstellenereignisse).
+
+## Scope
+- Event-Subscriber + Log-Pipeline (nur Stub)
+- Export/Archiv-Placeholder
+- Integrität/Unveränderbarkeit: Konzeptnotiz
+
+## @todo
+- [ ] Ereigniskatalog + Feldschema
+- [ ] Signierte Log-Bundles / Hash-Ketten (Design-Notiz)
+- [ ] Export-/Archiv-CLI-Stub
+- [ ] SIEM-Hook (nur Interface)

--- a/Beispiele/B2GAuditLogging/composer.json
+++ b/Beispiele/B2GAuditLogging/composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "b2g/audit-logging",
+  "description": "Skeleton: Audit-Trail für B2G",
+  "type": "shopware-platform-plugin",
+  "autoload": { "psr-4": { "B2G\\AuditLogging\\": "src/" } },
+  "extra": { "shopware-plugin-class": "B2G\\AuditLogging\\B2GAuditLogging" },
+  "require": { "php": ">=8.1" }
+}

--- a/Beispiele/B2GAuditLogging/docs/REFERENZEN.md
+++ b/Beispiele/B2GAuditLogging/docs/REFERENZEN.md
@@ -1,0 +1,1 @@
+- Siehe: ../../Randnotizen/Audit_Logging.md

--- a/Beispiele/B2GAuditLogging/src/B2GAuditLogging.php
+++ b/Beispiele/B2GAuditLogging/src/B2GAuditLogging.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+namespace B2G\AuditLogging;
+
+use Shopware\Core\Framework\Plugin;
+
+final class B2GAuditLogging extends Plugin
+{
+    // @todo: event subscribers, export stubs
+}

--- a/Beispiele/B2GBackupStatus/README.md
+++ b/Beispiele/B2GBackupStatus/README.md
@@ -1,0 +1,12 @@
+# B2GBackupStatus (Skeleton)
+Admin-Infos zu letzten Backup-/Restore-Zeitpunkten via externem Endpoint (nur Anzeige/Health-Checks).
+
+## Scope
+- Admin-Widget/Seite (Stub)
+- Polling eines konfigurierbaren Status-Endpoints
+- Keine Backupfunktion – nur Darstellung/Health
+
+## @todo
+- [ ] System-Config (Endpoint, Token)
+- [ ] Admin-Module (Stub UI)
+- [ ] Health-Indicator in Administration

--- a/Beispiele/B2GBackupStatus/composer.json
+++ b/Beispiele/B2GBackupStatus/composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "b2g/backup-status",
+  "description": "Skeleton: Anzeige Backup/Restore-Status (Admin)",
+  "type": "shopware-platform-plugin",
+  "autoload": { "psr-4": { "B2G\\BackupStatus\\": "src/" } },
+  "extra": { "shopware-plugin-class": "B2G\\BackupStatus\\B2GBackupStatus" },
+  "require": { "php": ">=8.1" }
+}

--- a/Beispiele/B2GBackupStatus/docs/REFERENZEN.md
+++ b/Beispiele/B2GBackupStatus/docs/REFERENZEN.md
@@ -1,0 +1,1 @@
+- Siehe: ../../Randnotizen/DrBackup_&_Wiederherstellung.md

--- a/Beispiele/B2GBackupStatus/src/B2GBackupStatus.php
+++ b/Beispiele/B2GBackupStatus/src/B2GBackupStatus.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+namespace B2G\BackupStatus;
+
+use Shopware\Core\Framework\Plugin;
+
+final class B2GBackupStatus extends Plugin
+{
+    // @todo: admin module for displaying backup health
+}

--- a/Beispiele/B2GCostCenters/README.md
+++ b/Beispiele/B2GCostCenters/README.md
@@ -1,0 +1,13 @@
+# B2GCostCenters (Skeleton)
+Kostenstellen-Pflicht im Checkout, Budgetprüfung, ERP-Abgleich (nur Stubs).
+
+## Scope
+- Entities: CostCenter, BudgetPeriod (Migrations-Stubs)
+- Checkout-Guard (Stub)
+- Reporting-Placeholder
+
+## @todo
+- [ ] Pflichtauswahl + Validierung gegen Budget
+- [ ] Abzugslogik bei APPROVED, Storno-Gutschrift
+- [ ] ERP-Sync-Interfaces (Import/Export)
+- [ ] Admin-Reports (Stub)

--- a/Beispiele/B2GCostCenters/composer.json
+++ b/Beispiele/B2GCostCenters/composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "b2g/cost-centers",
+  "description": "Skeleton: Kostenstellen & Budgets für B2G",
+  "type": "shopware-platform-plugin",
+  "autoload": { "psr-4": { "B2G\\CostCenters\\": "src/" } },
+  "extra": { "shopware-plugin-class": "B2G\\CostCenters\\B2GCostCenters" },
+  "require": { "php": ">=8.1" }
+}

--- a/Beispiele/B2GCostCenters/docs/REFERENZEN.md
+++ b/Beispiele/B2GCostCenters/docs/REFERENZEN.md
@@ -1,0 +1,1 @@
+- Siehe: ../../Randnotizen/Kostenstellen_&_Budgets.md

--- a/Beispiele/B2GCostCenters/src/B2GCostCenters.php
+++ b/Beispiele/B2GCostCenters/src/B2GCostCenters.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+namespace B2G\CostCenters;
+
+use Shopware\Core\Framework\Plugin;
+
+final class B2GCostCenters extends Plugin
+{
+    // @todo: entities, checkout guard, sync stubs
+}

--- a/Beispiele/B2GCustomForms/README.md
+++ b/Beispiele/B2GCustomForms/README.md
@@ -1,0 +1,13 @@
+# B2GCustomForms (Skeleton)
+Schema-basierte Formulare (Frontend), Validierung, Export (JSON/XML), Übergabe an Fachverfahren (Stub).
+
+## Scope
+- Form-Schema + Renderer (nur Interfaces)
+- Validierung server-/clientseitig (Skizze)
+- Export/Dispatch-Hooks (Stub)
+
+## @todo
+- [ ] Entity FormDefinition + Versionierung (Stub)
+- [ ] API: Submit → Validation → Dispatch
+- [ ] DSGVO/Löschkonzept Notiz
+- [ ] A11y-Form-Patterns

--- a/Beispiele/B2GCustomForms/composer.json
+++ b/Beispiele/B2GCustomForms/composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "b2g/custom-forms",
+  "description": "Skeleton: Dynamische Formulare & Fachverfahren",
+  "type": "shopware-platform-plugin",
+  "autoload": { "psr-4": { "B2G\\CustomForms\\": "src/" } },
+  "extra": { "shopware-plugin-class": "B2G\\CustomForms\\B2GCustomForms" },
+  "require": { "php": ">=8.1" }
+}

--- a/Beispiele/B2GCustomForms/docs/REFERENZEN.md
+++ b/Beispiele/B2GCustomForms/docs/REFERENZEN.md
@@ -1,0 +1,1 @@
+- Siehe: ../../Randnotizen/CustomForms.md

--- a/Beispiele/B2GCustomForms/src/B2GCustomForms.php
+++ b/Beispiele/B2GCustomForms/src/B2GCustomForms.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+namespace B2G\CustomForms;
+
+use Shopware\Core\Framework\Plugin;
+
+final class B2GCustomForms extends Plugin
+{
+    // @todo: form schema/renderer/dispatch stubs
+}

--- a/Beispiele/B2GCustomerRBAC/README.md
+++ b/Beispiele/B2GCustomerRBAC/README.md
@@ -1,0 +1,13 @@
+# B2GCustomerRBAC (Skeleton)
+RBAC für Kunden-Unterkonten (Organisation → Benutzer mit Rollen), Funktionstrennung, Reporting (Stubs).
+
+## Scope
+- Orga-/User-/Role-Entities (nur Stubs)
+- Policy-Gates (Server-seitig) – Platzhalter
+- Rollen-Reports (Export-Stubs)
+
+## @todo
+- [ ] Datenmodell (Orga, OrgaUser, Role)
+- [ ] Policy-Layer (Server)
+- [ ] Admin-UI (Zuweisungen)
+- [ ] Rezertifizierungs-Export

--- a/Beispiele/B2GCustomerRBAC/composer.json
+++ b/Beispiele/B2GCustomerRBAC/composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "b2g/customer-rbac",
+  "description": "Skeleton: Kunden-RBAC/Unterkonten",
+  "type": "shopware-platform-plugin",
+  "autoload": { "psr-4": { "B2G\\CustomerRBAC\\": "src/" } },
+  "extra": { "shopware-plugin-class": "B2G\\CustomerRBAC\\B2GCustomerRBAC" },
+  "require": { "php": ">=8.1" }
+}

--- a/Beispiele/B2GCustomerRBAC/docs/REFERENZEN.md
+++ b/Beispiele/B2GCustomerRBAC/docs/REFERENZEN.md
@@ -1,0 +1,1 @@
+- Siehe: ../../Randnotizen/Rollen_&_Rechte.md

--- a/Beispiele/B2GCustomerRBAC/src/B2GCustomerRBAC.php
+++ b/Beispiele/B2GCustomerRBAC/src/B2GCustomerRBAC.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+namespace B2G\CustomerRBAC;
+
+use Shopware\Core\Framework\Plugin;
+
+final class B2GCustomerRBAC extends Plugin
+{
+    // @todo: entities, policy gates, reports stubs
+}

--- a/Beispiele/B2GCustomerSSO/README.md
+++ b/Beispiele/B2GCustomerSSO/README.md
@@ -1,0 +1,13 @@
+# B2GCustomerSSO (Skeleton)
+SSO via SAML 2.0 / OpenID Connect (nur Konfig-/Flow-Stubs, kein produktives Auth).
+
+## Scope
+- Config-Form: Endpunkte/Keys/Scopes (Stub)
+- Token/Assertion-Validierungs-Interfaces (Platzhalter)
+- Mapping-Konzept (Gruppen → Rollen)
+
+## @todo
+- [ ] SystemConfig: saml/oidc
+- [ ] Login-Start/Callback-Controller (Stub)
+- [ ] Mapping-Hook zu RBAC
+- [ ] Deprovisioning-Notiz

--- a/Beispiele/B2GCustomerSSO/composer.json
+++ b/Beispiele/B2GCustomerSSO/composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "b2g/customer-sso",
+  "description": "Skeleton: SSO (SAML/OIDC) für Kunden",
+  "type": "shopware-platform-plugin",
+  "autoload": { "psr-4": { "B2G\\CustomerSSO\\": "src/" } },
+  "extra": { "shopware-plugin-class": "B2G\\CustomerSSO\\B2GCustomerSSO" },
+  "require": { "php": ">=8.1" }
+}

--- a/Beispiele/B2GCustomerSSO/docs/REFERENZEN.md
+++ b/Beispiele/B2GCustomerSSO/docs/REFERENZEN.md
@@ -1,0 +1,1 @@
+- Siehe: ../../Randnotizen/Single_Sign-On_&_IdM.md

--- a/Beispiele/B2GCustomerSSO/src/B2GCustomerSSO.php
+++ b/Beispiele/B2GCustomerSSO/src/B2GCustomerSSO.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+namespace B2G\CustomerSSO;
+
+use Shopware\Core\Framework\Plugin;
+
+final class B2GCustomerSSO extends Plugin
+{
+    // @todo: sso config, dummy controllers, mapping stubs
+}

--- a/Beispiele/B2GERPConnector/README.md
+++ b/Beispiele/B2GERPConnector/README.md
@@ -1,0 +1,13 @@
+# B2GERPConnector (Skeleton)
+ERP-Schnittstellen: Stammdaten-Import, Order-Export (nach Approval), Idempotenz/Retry-Stubs.
+
+## Scope
+- Import-/Export-Jobs (Interfaces)
+- Mapping/Transform (Pseudocode)
+- Status/Fehlertransparenz (Admin-Hinweise)
+
+## @todo
+- [ ] Job-Interfaces: ImportProducts/Prices/Stock
+- [ ] Order-Export-Stub (nur nach APPROVED)
+- [ ] Queue/Retry/Dead-Letter-Konzept
+- [ ] Monitoring-Hooks (z. B. Metriken)

--- a/Beispiele/B2GERPConnector/composer.json
+++ b/Beispiele/B2GERPConnector/composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "b2g/erp-connector",
+  "description": "Skeleton: ERP-Schnittstellen für B2G",
+  "type": "shopware-platform-plugin",
+  "autoload": { "psr-4": { "B2G\\ERPConnector\\": "src/" } },
+  "extra": { "shopware-plugin-class": "B2G\\ERPConnector\\B2GERPConnector" },
+  "require": { "php": ">=8.1" }
+}

--- a/Beispiele/B2GERPConnector/docs/REFERENZEN.md
+++ b/Beispiele/B2GERPConnector/docs/REFERENZEN.md
@@ -1,0 +1,1 @@
+- Siehe: ../../Randnotizen/ERP_Schnittstellen.md

--- a/Beispiele/B2GERPConnector/src/B2GERPConnector.php
+++ b/Beispiele/B2GERPConnector/src/B2GERPConnector.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+namespace B2G\ERPConnector;
+
+use Shopware\Core\Framework\Plugin;
+
+final class B2GERPConnector extends Plugin
+{
+    // @todo: jobs & mapping stubs
+}

--- a/Beispiele/B2GInvoicingXRechnung/README.md
+++ b/Beispiele/B2GInvoicingXRechnung/README.md
@@ -1,0 +1,13 @@
+# B2GInvoicingXRechnung (Skeleton)
+XRechnung (EN 16931) Generator/Validator + Versand-Stubs (PEPPOL/E-Mail) – rein konzeptionelle Platzhalter.
+
+## Scope
+- XML-Builder-Interface + Validator-Stub
+- Admin-Aktion: "XRechnung exportieren" (Stub)
+- Fehlerdialoge/Retry – nur Skizze
+
+## @todo
+- [ ] Custom Fields: Leitweg-ID/Referenzen (Hinweis)
+- [ ] XML/Schematron-Validator-Interface
+- [ ] Versandstrategie-Konfigurator (Stub)
+- [ ] Archiv-/Download-Platzhalter

--- a/Beispiele/B2GInvoicingXRechnung/composer.json
+++ b/Beispiele/B2GInvoicingXRechnung/composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "b2g/invoicing-xrechnung",
+  "description": "Skeleton: XRechnung Generator/Validator für B2G",
+  "type": "shopware-platform-plugin",
+  "autoload": { "psr-4": { "B2G\\InvoicingXRechnung\\": "src/" } },
+  "extra": { "shopware-plugin-class": "B2G\\InvoicingXRechnung\\B2GInvoicingXRechnung" },
+  "require": { "php": ">=8.1" }
+}

--- a/Beispiele/B2GInvoicingXRechnung/docs/REFERENZEN.md
+++ b/Beispiele/B2GInvoicingXRechnung/docs/REFERENZEN.md
@@ -1,0 +1,1 @@
+- Siehe: ../../Randnotizen/Invoicing_XRechnung_ZUGFeRD.md

--- a/Beispiele/B2GInvoicingXRechnung/src/B2GInvoicingXRechnung.php
+++ b/Beispiele/B2GInvoicingXRechnung/src/B2GInvoicingXRechnung.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+namespace B2G\InvoicingXRechnung;
+
+use Shopware\Core\Framework\Plugin;
+
+final class B2GInvoicingXRechnung extends Plugin
+{
+    // @todo: generator/validator/dispatch stubs
+}

--- a/Beispiele/B2GMandantTheme/README.md
+++ b/Beispiele/B2GMandantTheme/README.md
@@ -1,0 +1,12 @@
+# B2GMandantTheme (Skeleton Theme)
+Mandantenspezifisches Branding (Logos/Farben/Fonts), AA-Kontraste und Fokus-Stile als Startpunkt.
+
+## Scope
+- theme.json + SCSS-Vars
+- Beispiel-Konfiguration je Sales Channel (Doku)
+- Keine komplexen Templates; nur Startbasis
+
+## @todo
+- [ ] Farb-/Font-Variablen (AA)
+- [ ] Fokus-Indikatoren global
+- [ ] Beispiel-Logo-Slots

--- a/Beispiele/B2GMandantTheme/docs/REFERENZEN.md
+++ b/Beispiele/B2GMandantTheme/docs/REFERENZEN.md
@@ -1,0 +1,1 @@
+- Siehe: ../../Randnotizen/Theming_&_Branding_Mandanten.md

--- a/Beispiele/B2GMandantTheme/src/Resources/app/storefront/src/scss/base.scss
+++ b/Beispiele/B2GMandantTheme/src/Resources/app/storefront/src/scss/base.scss
@@ -1,0 +1,4 @@
+// @todo: Farb-/Font-Variablen mit AA-Kontrast
+// $color-primary: ...;
+// Focus styles
+:focus { outline: 2px solid; outline-offset: 2px; }

--- a/Beispiele/B2GMandantTheme/theme.json
+++ b/Beispiele/B2GMandantTheme/theme.json
@@ -1,0 +1,10 @@
+{
+  "name": "B2G Mandant Theme",
+  "author": "B2G",
+  "views": [
+    "@Storefront"
+  ],
+  "style": [
+    "app/storefront/src/scss/base.scss"
+  ]
+}

--- a/Beispiele/B2GMandateManagement/README.md
+++ b/Beispiele/B2GMandateManagement/README.md
@@ -1,0 +1,13 @@
+# B2GMandateManagement (Skeleton)
+Stellvertretungen "im Auftrag von …" + Delegation mit Scope/Betragsgrenzen (Stubs).
+
+## Scope
+- Mandat-Entity (Stub)
+- Impersonation/Delegated-Action: Konzept-Placeholder
+- Audit-Notizen
+
+## @todo
+- [ ] Mandatsverwaltung (Admin/Orga-UI stub)
+- [ ] Kontextwechsel UI-Hinweis
+- [ ] Approval-Integration (Vertreter prüfberechtigt)
+- [ ] Rezertifizierung/Expiry-Checks

--- a/Beispiele/B2GMandateManagement/composer.json
+++ b/Beispiele/B2GMandateManagement/composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "b2g/mandate-management",
+  "description": "Skeleton: Stellvertretung & Delegation für B2G",
+  "type": "shopware-platform-plugin",
+  "autoload": { "psr-4": { "B2G\\MandateManagement\\": "src/" } },
+  "extra": { "shopware-plugin-class": "B2G\\MandateManagement\\B2GMandateManagement" },
+  "require": { "php": ">=8.1" }
+}

--- a/Beispiele/B2GMandateManagement/docs/REFERENZEN.md
+++ b/Beispiele/B2GMandateManagement/docs/REFERENZEN.md
@@ -1,0 +1,1 @@
+- Siehe: ../../Randnotizen/Mandate_Management.md

--- a/Beispiele/B2GMandateManagement/src/B2GMandateManagement.php
+++ b/Beispiele/B2GMandateManagement/src/B2GMandateManagement.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+namespace B2G\MandateManagement;
+
+use Shopware\Core\Framework\Plugin;
+
+final class B2GMandateManagement extends Plugin
+{
+    // @todo: entities, impersonation/delegation stubs
+}

--- a/Beispiele/B2GMonitoringHooks/README.md
+++ b/Beispiele/B2GMonitoringHooks/README.md
@@ -1,0 +1,12 @@
+# B2GMonitoringHooks (Skeleton)
+Health-/Metrics-Endpunkte, Schnittstellen-Checks (ERP/Punchout/XRechnung) als Stubs.
+
+## Scope
+- /_health (HTTP 200/500, minimal)
+- Schnittstellen-Synthetics (nur Pseudocode)
+- Admin-Hinweise/Docs
+
+## @todo
+- [ ] Controller: /_health, /_metrics (Stub)
+- [ ] Checks: ERP-Job-Lag, Punchout Reachability, Last XRechnung Versand
+- [ ] Konfiguration + Simple Dash-Hinweis

--- a/Beispiele/B2GMonitoringHooks/composer.json
+++ b/Beispiele/B2GMonitoringHooks/composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "b2g/monitoring-hooks",
+  "description": "Skeleton: Health/Metrics Hooks",
+  "type": "shopware-platform-plugin",
+  "autoload": { "psr-4": { "B2G\\MonitoringHooks\\": "src/" } },
+  "extra": { "shopware-plugin-class": "B2G\\MonitoringHooks\\B2GMonitoringHooks" },
+  "require": { "php": ">=8.1" }
+}

--- a/Beispiele/B2GMonitoringHooks/docs/REFERENZEN.md
+++ b/Beispiele/B2GMonitoringHooks/docs/REFERENZEN.md
@@ -1,0 +1,1 @@
+- Siehe: ../../Randnotizen/Monitoring_&_Alerting.md

--- a/Beispiele/B2GMonitoringHooks/src/B2GMonitoringHooks.php
+++ b/Beispiele/B2GMonitoringHooks/src/B2GMonitoringHooks.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+namespace B2G\MonitoringHooks;
+
+use Shopware\Core\Framework\Plugin;
+
+final class B2GMonitoringHooks extends Plugin
+{
+    // @todo: health/metrics endpoints, synthetic checks stubs
+}

--- a/Beispiele/B2GPunchoutConnector/README.md
+++ b/Beispiele/B2GPunchoutConnector/README.md
@@ -1,0 +1,13 @@
+# B2GPunchoutConnector (Skeleton)
+OCI/cXML Punchout (Setup, Session, Warenkorb-Rückgabe) + optionale PEPPOL BIS Hooks.
+
+## Scope
+- HTTP-Endpoints (nur Routen/Controller-Stubs)
+- Mapping: Partner-Credentials → Organisation/SalesChannel (Stub)
+- Warenkorb-Rückgabe (OCI NEW_ITEM*, cXML PunchOutOrderMessage) als Pseudocode
+
+## @todo
+- [ ] routes.xml + Controller-Stubs
+- [ ] Partner-Mapping-Interface
+- [ ] Beispiel-Response-Builder (Stub)
+- [ ] Error-/Retry-Konzepte (Notizen)

--- a/Beispiele/B2GPunchoutConnector/composer.json
+++ b/Beispiele/B2GPunchoutConnector/composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "b2g/punchout-connector",
+  "description": "Skeleton: OCI/cXML Punchout Connector",
+  "type": "shopware-platform-plugin",
+  "autoload": { "psr-4": { "B2G\\PunchoutConnector\\": "src/" } },
+  "extra": { "shopware-plugin-class": "B2G\\PunchoutConnector\\B2GPunchoutConnector" },
+  "require": { "php": ">=8.1" }
+}

--- a/Beispiele/B2GPunchoutConnector/docs/REFERENZEN.md
+++ b/Beispiele/B2GPunchoutConnector/docs/REFERENZEN.md
@@ -1,0 +1,1 @@
+- Siehe: ../../Randnotizen/Broker_Integration_Punchout_&_Katalog.md

--- a/Beispiele/B2GPunchoutConnector/src/B2GPunchoutConnector.php
+++ b/Beispiele/B2GPunchoutConnector/src/B2GPunchoutConnector.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+namespace B2G\PunchoutConnector;
+
+use Shopware\Core\Framework\Plugin;
+
+final class B2GPunchoutConnector extends Plugin
+{
+    // @todo: register routes, controller stubs
+}


### PR DESCRIPTION
## Summary
- add documentation and composer manifests for new B2G example plugins
- scaffold plugin entry classes as Shopware skeletons
- provide mandant theme skeleton with base SCSS placeholder

## Testing
- not run