### PR TITLE
Add PO todos for missing acceptance coverage

### DIFF
--- a/Randnotizen/Accessibility_Barrierefreiheit.md
+++ b/Randnotizen/Accessibility_Barrierefreiheit.md
@@ -28,9 +28,11 @@ Der Shop muss für alle Nutzer:innen uneingeschränkt bedienbar sein und **WCAG 
 - [x] WCAG-Audit inkl. manueller Screenreader-Prüfung durchgeführt  
 - [x] Tastaturbedienbarkeit & sichtbarer Fokus sichergestellt  
 - [x] Fehlerhandling mit `aria-live`/Fokus  
-- [x] Barrierefreiheitserklärung + Feedback-Prozess veröffentlicht [28]  
-- [x] Redaktion geschult; Leitfaden dokumentiert  
+- [x] Barrierefreiheitserklärung + Feedback-Prozess veröffentlicht [28]
+- [x] Redaktion geschult; Leitfaden dokumentiert
 - [x] Wiederkehrende Prüfung (manuell + Tooling) in Pipeline verankert
+
+> @todo (PO): Akzeptanzkriterien für Accessibility (Wenn Nutzer:in X, Dann Ergebnis Y, gemessen durch Z) definieren.
 
 ## Abhängigkeiten/Überschneidungen
 - **Theming & Branding:** Kontraste, Fonts, Fokus-Stile.  

--- a/Randnotizen/Approval_Workflow.md
+++ b/Randnotizen/Approval_Workflow.md
@@ -25,8 +25,10 @@ Behörden arbeiten formalisiert und fristgebunden. Jede Zeichnung muss **nachvol
 - [x] Eskalationsketten/Fristen definiert  
 - [x] Stellvertretung integriert (s. Mandate_Management)  
 - [x] UI für Genehmiger & Besteller konzipiert  
-- [x] Audit-Trail & Reporting implementiert  
+- [x] Audit-Trail & Reporting implementiert
 - [x] E2E-Tests/Betragsschwellen/Edge-Cases
+
+> @todo (PO): Akzeptanzkriterien für Freigabefälle (Wenn Order-Level X, Dann Genehmigungsstatus Y innerhalb Z Zeit) ergänzen.
 
 ## Abhängigkeiten/Überschneidungen
 - **Rollen & Rechte:** Wer darf freigeben?  

--- a/Randnotizen/Audit_Logging.md
+++ b/Randnotizen/Audit_Logging.md
@@ -17,9 +17,11 @@
 ## Checkliste
 - [x] Ereigniskatalog + Felder definiert  
 - [x] Fälschungsschutz/Unveränderbarkeit implementiert  
-- [x] Aufbewahrungsfristen & Exportfunktion  
-- [x] SIEM-Anbindung + Alarmregeln  
+- [x] Aufbewahrungsfristen & Exportfunktion
+- [x] SIEM-Anbindung + Alarmregeln
 - [x] Rechte-Rezertifizierung dokumentiert
+
+> @todo (PO): Akzeptanzkriterien für Audit-Logs (Wann gilt Eintrag als revisionssicher, wie wird Export geprüft?) formulieren.
 
 ## Abhängigkeiten/Überschneidungen
 - **Rollen & Rechte:** Protokolliert Zuweisungen/Änderungen.  

--- a/Randnotizen/B2G_Besonderheiten.md
+++ b/Randnotizen/B2G_Besonderheiten.md
@@ -24,3 +24,6 @@ Beschaffungs-/Service-Portale für Behörden müssen **rechtskonform, nachvollzi
 
 ## Checkliste (kurz)
 - Rollen/Workflows geklärt? • Mandantenmodell? • E-Rechnung? • SSO/IDM? • WCAG? • Audit/Monitoring/Backup? • Externe Standards & Schnittstellen?
+
+> @todo (PO): Akzeptanzkriterien für die Gesamtsicht (Welche Minimalnachweise müssen erfüllt sein?) definieren.
+> @todo (PO): Abhängigkeiten zu Detail-Randnotizen explizit verlinken (z. B. Approval ↔ Kostenstellen ↔ ERP).

--- a/Randnotizen/B2G_Technische_Auswirkungen.md
+++ b/Randnotizen/B2G_Technische_Auswirkungen.md
@@ -18,3 +18,7 @@
 
 ## Shopware-Implikationen
 - OOTB reicht selten: **Plugins/Custom-Module** für Rollen, Approval, CostCenter, E-Invoice, SSO, Audit, etc.
+
+> @todo (PO): Checkliste ableiten (Welche technischen Leitplanken müssen erfüllt sein?).
+> @todo (PO): Abhängigkeiten zu Spezialthemen (z. B. Monitoring, Backup, Security) strukturieren.
+> @todo (PO): Akzeptanzkriterien für Architektur-Guidelines formulieren.

--- a/Randnotizen/Betrieb_&_Governance.md
+++ b/Randnotizen/Betrieb_&_Governance.md
@@ -19,9 +19,12 @@ Klar definierte Verantwortlichkeiten und Prozesse für Betrieb, Monitoring, Eska
 ## Checkliste
 - [x] Runbooks erstellt & getestet  
 - [x] Eskalationsketten definiert  
-- [x] Bereitschaftsdienst organisiert  
-- [x] Betriebshandbuch gepflegt  
+- [x] Bereitschaftsdienst organisiert
+- [x] Betriebshandbuch gepflegt
 - [x] Governance-Richtlinien umgesetzt
+
+> @todo (PO): Akzeptanzkriterien für Betriebsprozesse (z. B. maximale Reaktionszeit, Nachweis der Runbook-Übung) beschreiben.
+> @todo (PO): Abhängigkeiten zu Monitoring, Backup und Change-Management ergänzen.
 
 ## Quellen
 [4][13]

--- a/Randnotizen/Broker_Integration_Punchout_&_Katalog.md
+++ b/Randnotizen/Broker_Integration_Punchout_&_Katalog.md
@@ -19,9 +19,11 @@ Anbindung an e-Procurement-Systeme (z. B. SAP SRM/Ariba, Jaggaer, Coupa): **Punc
 - [x] Standards/Partneranforderungen abgestimmt  
 - [x] Setup-Flows/Sessionmanagement implementiert  
 - [x] Katalogeinschränkung/Preise je Mandant [23]  
-- [x] Warenkorb-Transfer (OCI/cXML)  
-- [x] Fehlerfälle & Wiederholungen  
+- [x] Warenkorb-Transfer (OCI/cXML)
+- [x] Fehlerfälle & Wiederholungen
 - [x] Partner-Doku & E2E-Tests
+
+> @todo (PO): Akzeptanzkriterien für Punchout/Katalog (z. B. erfolgreiche OCI-Rückgabe, cXML-Validierung) festlegen.
 
 ## Abhängigkeiten/Überschneidungen
 - **ERP-Schnittstellen:** Preis-/Stammdatenquelle, Orderimport.  

--- a/Randnotizen/Change_&_Release.md
+++ b/Randnotizen/Change_&_Release.md
@@ -20,8 +20,11 @@
 - [x] Risikoanalyse durchgeführt  
 - [x] Tests in Staging erfolgreich  
 - [x] Abnahme dokumentiert  
-- [x] Rollback-Szenario getestet  
+- [x] Rollback-Szenario getestet
 - [x] Release in Change-Log dokumentiert
+
+> @todo (PO): Akzeptanzkriterien für Releases (wann gilt ein Change als abgenommen, welche KPIs) definieren.
+> @todo (PO): Abhängigkeiten zu Betrieb/Testing/Risikomanagement dokumentieren.
 
 ## Quellen
 [12][18]

--- a/Randnotizen/CustomForms.md
+++ b/Randnotizen/CustomForms.md
@@ -17,12 +17,14 @@ Das **OZG** treibt die Digitalisierung von Verwaltungsleistungen. Formulare verm
 - [x] Formularmodelle & Pflichtfelder definiert  
 - [x] A11y-gerechte UI & Fehlermeldungen  
 - [x] Export/Integration in Fachverfahren  
-- [x] Datenschutz-Hinweise pro Formular  
+- [x] Datenschutz-Hinweise pro Formular
 - [x] Monitoring der Übermittlungen + Retry
 
 ## Abhängigkeiten/Überschneidungen
-- **Accessibility:** A11y-Regeln aus Accessibility_Barrierefreiheit.  
+- **Accessibility:** A11y-Regeln aus Accessibility_Barrierefreiheit.
 - **ERP/eVergabe/DMS:** Zielsystem-Schnittstellen & Mappings.
+
+> @todo (PO): Akzeptanzkriterien für Formularübermittlungen (z. B. Validierungsfehlerquote, erfolgreiche Übergabe ans Fachverfahren) ausformulieren.
 
 ## Quellen
 [16]

--- a/Randnotizen/Dokumentation_&_Archivierung.md
+++ b/Randnotizen/Dokumentation_&_Archivierung.md
@@ -20,9 +20,12 @@ Alle relevanten Unterlagen, Nachweise und Protokolle rechts- und revisionssicher
 - [x] Vergabedokumentation vollständig  
 - [x] Betriebs- und Änderungsdokumentation gepflegt  
 - [x] Audit-Trails gesichert/archiviert  
-- [x] Rechnungsdaten revisionssicher gespeichert  
-- [x] A11y-Nachweise abgelegt  
+- [x] Rechnungsdaten revisionssicher gespeichert
+- [x] A11y-Nachweise abgelegt
 - [x] Archivierungspflichten überprüft
+
+> @todo (PO): Akzeptanzkriterien für Dokumentations-/Archivierungsnachweise definieren (z. B. Vollständigkeits- und Aufbewahrungsprüfungen).
+> @todo (PO): Abhängigkeiten zu Audit-Logging, Change-Management und Invoicing sichtbar machen.
 
 ## Quellen
 [2][3][4][7][8][18]

--- a/Randnotizen/DrBackup_&_Wiederherstellung.md
+++ b/Randnotizen/DrBackup_&_Wiederherstellung.md
@@ -14,13 +14,15 @@ Wiederherstellung des Betriebs innerhalb definierter **RTO** bei maximalem **RPO
 - [x] RPO/RTO definiert & mit Auftraggeber abgestimmt  
 - [x] Backup-Jobs stabil + überwacht  
 - [x] Restore-Test erfolgreich dokumentiert  
-- [x] Notfallhandbuch/Runbooks gepflegt  
-- [x] Zugriff/Schlüsselmanagement geprüft  
+- [x] Notfallhandbuch/Runbooks gepflegt
+- [x] Zugriff/Schlüsselmanagement geprüft
 - [x] Langzeit-Archivierung geregelt
 
 ## Abhängigkeiten/Überschneidungen
-- **Monitoring:** Backup-Fehler/Alter der Sicherungen alarmieren.  
+- **Monitoring:** Backup-Fehler/Alter der Sicherungen alarmieren.
 - **Audit:** Nachweise zu Tests/Aufbewahrung.
+
+> @todo (PO): Akzeptanzkriterien für RPO/RTO-Nachweise und Restore-Tests definieren.
 
 ## Quellen
 [10][11][17]

--- a/Randnotizen/ERP_Schnittstellen.md
+++ b/Randnotizen/ERP_Schnittstellen.md
@@ -13,13 +13,15 @@ ERP als **Single Source of Truth** für Artikel/Preise/Bestände; Shop übergibt
 ## Checkliste
 - [x] Formate/Protokolle/Frequenz abgestimmt  
 - [x] Mappingdoku + Testimporte erfolgreich  
-- [x] Order-Export + ERP-Auftragsnummer Rückfluss [24]  
-- [x] Monitoring (Throughput/Fehler) + Alarme  
+- [x] Order-Export + ERP-Auftragsnummer Rückfluss [24]
+- [x] Monitoring (Throughput/Fehler) + Alarme
 - [x] Betriebshandbuch/On-Call-Kontakt
 
 ## Abhängigkeiten/Überschneidungen
-- **Approval/Kostenstellen:** Export-Gate erst nach Freigabe/Budget.  
+- **Approval/Kostenstellen:** Export-Gate erst nach Freigabe/Budget.
 - **Invoicing:** Rechnungsdaten/Leitweg-ID an ERP/Versandsystem.
+
+> @todo (PO): Akzeptanzkriterien für ERP-Integrationen (z. B. Erfolgsquote, Latenz) definieren.
 
 ## Quellen
 [18][19][24]

--- a/Randnotizen/FAQ.md
+++ b/Randnotizen/FAQ.md
@@ -23,6 +23,8 @@
 - Logging: Event „ORDER_APPROVED“ inkl. Benutzer/Rolle
 
 ## Wer trägt Verantwortung für DR/Backup?
-- Betriebsteam legt RTO/RPO fest  
-- Regelmäßige Restore-Tests dokumentieren  
+- Betriebsteam legt RTO/RPO fest
+- Regelmäßige Restore-Tests dokumentieren
 - Ergebnisse im Notfallhandbuch ablegen
+
+> @todo (PO): Akzeptanzkriterien/Checkliste für FAQ-Abdeckung definieren (Welche Themen müssen beantwortet werden?).

--- a/Randnotizen/Invoicing_XRechnung_ZUGFeRD.md
+++ b/Randnotizen/Invoicing_XRechnung_ZUGFeRD.md
@@ -19,13 +19,15 @@ Erzeugung **valider XRechnung (EN 16931)** inkl. **Leitweg-ID** sowie Versand ü
 - [x] Pflichtfelder modelliert & gepflegt  
 - [x] XML-Generator + Validierung integriert  
 - [x] Versandweg definiert & getestet  
-- [x] Archivierung/Backup geregelt  
-- [x] Korrekturprozesse dokumentiert  
+- [x] Archivierung/Backup geregelt
+- [x] Korrekturprozesse dokumentiert
 - [x] ERP-Integration (Felder/Belege) [8][22]
 
 ## Abhängigkeiten/Überschneidungen
-- **ERP:** Belegdaten/Nummernkreise, Versandpfad.  
+- **ERP:** Belegdaten/Nummernkreise, Versandpfad.
 - **Audit:** Nachweise/Versandprotokolle.
+
+> @todo (PO): Akzeptanzkriterien für XRechnung (Validierungsnachweis, PEPPOL-Test, Archivprüfung) ergänzen.
 
 ## Quellen
 [8][9][14][16][17][22]

--- a/Randnotizen/Kostenstellen_&_Budgets.md
+++ b/Randnotizen/Kostenstellen_&_Budgets.md
@@ -13,13 +13,15 @@ Zuordnung von Bestellungen zu **Kostenstellen** (Pflicht) mit **Budgetprüfung**
 ## Checkliste
 - [x] Import/Mapping + Admin-UI  
 - [x] Pflichtauswahl & Validierung  
-- [x] Abzugslogik & Storno-Gutschrift  
-- [x] Reports/Exporte  
+- [x] Abzugslogik & Storno-Gutschrift
+- [x] Reports/Exporte
 - [x] ERP-Roundtrip getestet
 
 ## Abhängigkeiten/Überschneidungen
-- **Approval:** Überschreitung → Freigabestufe.  
+- **Approval:** Überschreitung → Freigabestufe.
 - **Rollen:** Wer darf Budgets pflegen/sehen?
+
+> @todo (PO): Akzeptanzkriterien für Budgetprüfungen (Fehlerfälle, Schwellenwerte, Reporting) festlegen.
 
 ## Quellen
 [10]

--- a/Randnotizen/Mandate_Management.md
+++ b/Randnotizen/Mandate_Management.md
@@ -15,13 +15,15 @@ Temporäre oder permanente **Vertretungen** („im Auftrag von …“) und **Del
 ## Checkliste
 - [x] Mandatsentitäten/Scope modelliert  
 - [x] UI für Einrichtung/Wechsel  
-- [x] Approval-Integration (Vertreter freigabeberechtigt)  
-- [x] Audit-Trails mit „im Auftrag von“  
+- [x] Approval-Integration (Vertreter freigabeberechtigt)
+- [x] Audit-Trails mit „im Auftrag von“
 - [x] Rezertifizierung/Überprüfung
 
 ## Abhängigkeiten/Überschneidungen
-- **Rollen & Rechte:** Basis für Berechtigungen.  
+- **Rollen & Rechte:** Basis für Berechtigungen.
 - **Approval/Kostenstellen:** Stellvertretung wirkt auf Freigaben/Budgets.
+
+> @todo (PO): Akzeptanzkriterien für Mandatsnutzung (z. B. Nachweis im Audit-Log, Ablauf von Mandaten) festlegen.
 
 ## Quellen
 [18][19]

--- a/Randnotizen/Monitoring_&_Alerting.md
+++ b/Randnotizen/Monitoring_&_Alerting.md
@@ -17,13 +17,15 @@ Transparenz über Verfügbarkeit/Leistung, **Schnittstellenintegrität** und **S
 ## Checkliste
 - [x] Dashboards/Alarme eingerichtet  
 - [x] Schnittstellen-Synthetics & Thresholds  
-- [x] SIEM-Regeln für Security-Events  
-- [x] Reports/Export für Revision  
+- [x] SIEM-Regeln für Security-Events
+- [x] Reports/Export für Revision
 - [x] Probealarme erfolgreich
 
 ## Abhängigkeiten/Überschneidungen
-- **Audit-Logging:** Ereignisquelle/Correlation.  
+- **Audit-Logging:** Ereignisquelle/Correlation.
 - **ERP/Punchout:** Synthetische Checks/Partner-Sichtbarkeit.
+
+> @todo (PO): Akzeptanzkriterien für Monitoring (SLA-Nachweise, Alarm-Reaktionszeiten) definieren.
 
 ## Quellen
 [4][9][12][13][16]

--- a/Randnotizen/README.md
+++ b/Randnotizen/README.md
@@ -6,6 +6,8 @@ Diese Sammlung bündelt die wichtigsten Problemstellungen und Lösungsansätze i
 ## Allgemeiner Teil
 - [B2G_Besonderheiten](B2G_Besonderheiten.md) – Rechtliches/organisatorisches Umfeld, typische Prozesse, Pflichten.
 - [B2G_Technische_Auswirkungen](B2G_Technische_Auswirkungen.md) – Architektur- und Sicherheitsimplikationen, Standards, Muster.
+> @todo (PO): Beispiel-Skeleton für B2G_Besonderheiten anlegen / Scope abstimmen
+> @todo (PO): Beispiel-Skeleton für B2G_Technische_Auswirkungen anlegen / Scope abstimmen
 
 ## Module (Shopware-spezifische Deep Dives)
 - [Rollen_&_Rechte](Rollen_&_Rechte.md) – Granulare Rollen & Berechtigungen, Unterkonten.
@@ -22,5 +24,9 @@ Diese Sammlung bündelt die wichtigsten Problemstellungen und Lösungsansätze i
 - [Audit_Logging](Audit_Logging.md) – Revisionssichere Protokolle, Scope, Aufbewahrung.
 - [Monitoring_&_Alerting](Monitoring_&_Alerting.md) – Uptime/APM/Logs/Security-Signale, Alarmierung, Berichte.
 - [DrBackup_&_Wiederherstellung](DrBackup_&_Wiederherstellung.md) – Backup/Restore, RPO/RTO, DR-Playbooks, Verschlüsselung.
+> @todo (PO): Beispiel-Skeleton für Betrieb & Governance anlegen / Scope abstimmen
+> @todo (PO): Beispiel-Skeleton für Change & Release anlegen / Scope abstimmen
+> @todo (PO): Beispiel-Skeleton für Dokumentation & Archivierung anlegen / Scope abstimmen
+> @todo (PO): Beispiel-Skeleton für Testing & Abnahme anlegen / Scope abstimmen
 
 > Hinweis: Inhalte sind **kundengenerisch** formuliert (keine Namen). Jede Seite enthält: *Kundenanforderung*, *Warum (Kontext)*, *B2G-Besonderheiten*, *Was fehlt OOTB*, *Technische Umsetzung (Allgemein)*, *Spezifisch für Shopware*, *Abhängigkeiten/Überschneidungen*, *Checkliste*.

--- a/Randnotizen/Rollen_&_Rechte.md
+++ b/Randnotizen/Rollen_&_Rechte.md
@@ -21,13 +21,15 @@ Mehrbenutzer-Organisationen (Behörden) mit **feingranularen Berechtigungen** f�
 ## Checkliste
 - [x] Rollenmodell & Hierarchien definiert  
 - [x] Datenmodell & Migrationen  
-- [x] Admin-UI & Reports  
-- [x] Policy-Enforcement/Tests  
+- [x] Admin-UI & Reports
+- [x] Policy-Enforcement/Tests
 - [x] SSO-Mapping & Audit
 
 ## Abhängigkeiten/Überschneidungen
-- **Approval/Mandate:** Rechte wirken auf Genehmigungen/Vertretungen.  
+- **Approval/Mandate:** Rechte wirken auf Genehmigungen/Vertretungen.
 - **SSO/IdM:** Attribut-Mapping → Rollen.
+
+> @todo (PO): Akzeptanzkriterien für Rollenvergabe/Rezertifizierung definieren (z. B. Prüfintervalle, Audit-Belege).
 
 ## Quellen
 [15][16][19][21][4]

--- a/Randnotizen/Single_Sign-On_&_IdM.md
+++ b/Randnotizen/Single_Sign-On_&_IdM.md
@@ -12,14 +12,16 @@ Zentraler Login über den behördlichen **IdP** (z. B. Azure AD, Keycloak), **JI
 
 ## Checkliste (aus Recherche)
 - [x] Keine offenen Registrierungen (optional)  
-- [x] IdP-Zwang & Token-Prüfung (Signatur/Gültigkeit)  
-- [x] Gruppen/Rollen-Mapping geklärt  
-- [x] Deaktivierung wirkt (Login blockiert, Session invalidiert)  
+- [x] IdP-Zwang & Token-Prüfung (Signatur/Gültigkeit)
+- [x] Gruppen/Rollen-Mapping geklärt
+- [x] Deaktivierung wirkt (Login blockiert, Session invalidiert)
 - [x] Nutzerkommunikation/Umstellung dokumentiert [8]
 
 ## Abhängigkeiten/Überschneidungen
-- **Rollen & Rechte:** Mapping → Berechtigungen.  
+- **Rollen & Rechte:** Mapping → Berechtigungen.
 - **Audit-Logging:** Login/Logout/Attribute protokollieren.
+
+> @todo (PO): Akzeptanzkriterien für SSO (z. B. IdP-Failover, Token-Validierung, Deprovisioning-Laufzeit) festlegen.
 
 ## Quellen
 [2][8]

--- a/Randnotizen/Testing_&_Abnahme.md
+++ b/Randnotizen/Testing_&_Abnahme.md
@@ -20,9 +20,12 @@ Sicherstellen, dass alle B2G-spezifischen Funktionen (z. B. Punchout, XRechnung,
 - [x] Testplan erstellt  
 - [x] Automatisierte Tests (CI/CD) eingerichtet  
 - [x] Fachliche Abnahme dokumentiert  
-- [x] Schnittstellen-Endpunkte mit Partnern getestet  
-- [x] Validierung XRechnung erfolgreich  
+- [x] Schnittstellen-Endpunkte mit Partnern getestet
+- [x] Validierung XRechnung erfolgreich
 - [x] A11y-Tests (WCAG/BITV) durchgeführt
+
+> @todo (PO): Akzeptanzkriterien für Abnahmen (z. B. minimaler Testumfang, Nachweisformate) definieren.
+> @todo (PO): Abhängigkeiten zu Change/Betrieb/Monitoring dokumentieren.
 
 ## Quellen
 [3][7][8][15][16][18][22][24]

--- a/Randnotizen/Theming_&_Branding_Mandanten.md
+++ b/Randnotizen/Theming_&_Branding_Mandanten.md
@@ -18,14 +18,16 @@ CI-konforme Darstellung (Logo, Farben, Schriften, ggf. Hoheitszeichen) je **Orga
 ## Checkliste (aus Recherche)
 - [x] Channels/Theme-Configs je Organisation  
 - [x] Mandantenspezifische Inhalte (CMS/Impressum)  
-- [x] E-Mails/PDFs angepasst & getestet [11]  
-- [x] Performance/Kompatibilität geprüft  
-- [x] Konsistenz in Custom-Modulen  
+- [x] E-Mails/PDFs angepasst & getestet [11]
+- [x] Performance/Kompatibilität geprüft
+- [x] Konsistenz in Custom-Modulen
 - [x] Admin-Doku/Schulung
 
 ## Abhängigkeiten/Überschneidungen
-- **Accessibility:** Kontraste/Fokus/Typografie.  
+- **Accessibility:** Kontraste/Fokus/Typografie.
 - **Punchout:** Sichtbare Mandantenidentität im Flow.
+
+> @todo (PO): Akzeptanzkriterien für Mandanten-Themes (z. B. Kontrastnachweis, Browserkompatibilität, Mandantenwechsel) ausarbeiten.
 
 ## Quellen
 [7][10][11][13]


### PR DESCRIPTION
## Summary
- flag missing acceptance criteria across B2G randnotizen with explicit PO follow-ups
- note required skeleton mappings in the randnotizen overview where no example plugin exists

## Testing
- not run