### PR TITLE
Add skeleton collection for Shopware extension basics

### DIFF
--- a/shopware-basics/admin-extension/OVERVIEW.md
+++ b/shopware-basics/admin-extension/OVERVIEW.md
@@ -1,0 +1,10 @@
+# Übersicht: Administration Extension Skeleton
+
+- `README.md` – Anleitung zur Modul-Erstellung.
+- `skeleton.tree` – Verzeichnisstruktur.
+- `src/Resources/app/administration/src/main.js` – Registrierungspunkt.
+- `src/Resources/app/administration/src/module/acme-demo-module/index.js` – Modulkonfiguration.
+- `src/Resources/app/administration/src/module/acme-demo-module/page/acme-demo-list/index.js` – Vue-Komponente.
+- `src/Resources/app/administration/src/module/acme-demo-module/snippet/de-DE.json` – Snippet.
+- `src/Resources/app/administration/src/module/acme-demo-module/snippet/en-GB.json` (Optional) – weitere Sprache bei Bedarf.
+- `module.xml` – Aktivierung des Moduls.

--- a/shopware-basics/admin-extension/README.md
+++ b/shopware-basics/admin-extension/README.md
@@ -1,0 +1,38 @@
+# Administration Extension Skeleton
+
+## Was ist das?
+Dieses Skeleton stellt ein minimales Administration-Modul bereit, das im Shopware Backend eingebunden wird. Es dient als Grundlage für eigene Vue-Komponenten, Listen und Detailseiten.
+
+## Typische Anwendungsfälle
+- Custom-Module zur Pflege projektspezifischer Daten.
+- Dashboards oder Übersichten mit API-Anbindungen.
+- Erweiterung bestehender Admin-Funktionen durch zusätzliche Tabs.
+- Interne Tools für Support- oder Content-Teams.
+
+## Kurzes How-to
+1. Einstieg in `src/Resources/app/administration/src/main.js` prüfen und Module registrieren.
+2. Modulstruktur in `module/acme-demo-module/` erweitern (Routing, Komponenten, Services).
+3. Snippets in `snippet/de-DE.json` anpassen, weitere Sprachen ergänzen.
+4. Module mit `module.xml` aktivieren.
+5. Plugin/Bundle installieren und Administration neu kompilieren (`bin/console administration:build`).
+6. Cache leeren (`bin/console cache:clear`) und Modul im Admin unter Inhalt → Plugins testen.
+
+## Wann einsetzen / Wann nicht
+**Wann einsetzen:** Für individuelle Backend-Arbeitsoberflächen oder Konfigurationen, die Shopware nicht ab Werk liefert.
+**Wann nicht:** Wenn lediglich API-Endpunkte konsumiert werden sollen (dann ggf. externe Tools) oder für reine Storefront-Anpassungen.
+
+## Wo erweitern?
+- `src/Resources/app/administration/src/main.js` – Modulregistrierung.
+- `module/acme-demo-module/page/acme-demo-list/index.js` – Vue-Komponenten.
+- `module/acme-demo-module/snippet/de-DE.json` – Übersetzungen.
+- `module.xml` – Modul-Definition.
+
+## Weiterführend
+- Begriffe: ModuleFactory, ComponentFactory, RepositoryFactory.
+- Suche im Core nach `sw-extension-component-section`.
+- Themen: Administration Bundling, ACL Berechtigungen.
+
+## Hinweise für Produktion
+- ACL-Rechte für Module definieren.
+- UI-Tests (z. B. Cypress) einplanen.
+- Buildzeiten berücksichtigen und Artefakte cachen.

--- a/shopware-basics/admin-extension/module.xml
+++ b/shopware-basics/admin-extension/module.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" ?>
+<module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/Framework/Plugin/Schema/module-1.0.xsd">
+    <label>Acme Demo Module</label>
+    <source>Resources/app/administration/src/main.js</source>
+</module>

--- a/shopware-basics/admin-extension/skeleton.tree
+++ b/shopware-basics/admin-extension/skeleton.tree
@@ -1,0 +1,21 @@
+```
+admin-extension/
+├── README.md
+├── OVERVIEW.md
+├── module.xml
+├── skeleton.tree
+└── src
+    └── Resources
+        └── app
+            └── administration
+                └── src
+                    ├── main.js
+                    └── module
+                        └── acme-demo-module
+                            ├── index.js
+                            ├── page
+                            │   └── acme-demo-list
+                            │       └── index.js
+                            └── snippet
+                                └── de-DE.json
+```

--- a/shopware-basics/admin-extension/src/Resources/app/administration/src/main.js
+++ b/shopware-basics/admin-extension/src/Resources/app/administration/src/main.js
@@ -1,0 +1,3 @@
+import './module/acme-demo-module';
+
+// Bei Bedarf globale Komponenten, Sprachsnippets oder Services registrieren.

--- a/shopware-basics/admin-extension/src/Resources/app/administration/src/module/acme-demo-module/index.js
+++ b/shopware-basics/admin-extension/src/Resources/app/administration/src/module/acme-demo-module/index.js
@@ -1,0 +1,29 @@
+import './page/acme-demo-list';
+import './snippet/de-DE.json';
+
+const { Module } = Shopware;
+
+Module.register('acme-demo-module', {
+    type: 'plugin',
+    name: 'AcmeDemoModule',
+    title: 'acme-demo-module.general.title',
+    description: 'acme-demo-module.general.description',
+    color: '#9AA8B5',
+    icon: 'default-action-settings',
+
+    routes: {
+        list: {
+            component: 'acme-demo-list',
+            path: 'list',
+        },
+    },
+
+    navigation: [{
+        id: 'acme-demo-module-list',
+        parent: 'sw-extension',
+        label: 'acme-demo-module.general.navigation',
+        color: '#9AA8B5',
+        path: 'acme.demo.module.list',
+        position: 100,
+    }],
+});

--- a/shopware-basics/admin-extension/src/Resources/app/administration/src/module/acme-demo-module/page/acme-demo-list/index.js
+++ b/shopware-basics/admin-extension/src/Resources/app/administration/src/module/acme-demo-module/page/acme-demo-list/index.js
@@ -1,0 +1,10 @@
+const { Component } = Shopware;
+
+Component.register('acme-demo-list', {
+    template: `
+        <div class="acme-demo-list">
+            <h1>{{ $tc('acme-demo-module.general.title') }}</h1>
+            <p>[[Tabellen oder Listen über Repositories hier anbinden.]]</p>
+        </div>
+    `,
+});

--- a/shopware-basics/admin-extension/src/Resources/app/administration/src/module/acme-demo-module/snippet/de-DE.json
+++ b/shopware-basics/admin-extension/src/Resources/app/administration/src/module/acme-demo-module/snippet/de-DE.json
@@ -1,0 +1,9 @@
+{
+    "acme-demo-module": {
+        "general": {
+            "title": "Acme Demo Modul",
+            "description": "Skeleton für ein einfaches Admin-Modul.",
+            "navigation": "Acme Demo"
+        }
+    }
+}

--- a/shopware-basics/app-remote/OVERVIEW.md
+++ b/shopware-basics/app-remote/OVERVIEW.md
@@ -1,0 +1,8 @@
+# Übersicht: Remote App Skeleton
+
+- `README.md` – Überblick und Setup-Schritte.
+- `skeleton.tree` – Struktur der App.
+- `app/manifest.xml` – definiert Module, Webhooks, Berechtigungen.
+- `app/Resources/administration/main.js` – Einstieg für Admin-Oberfläche.
+- `app/Resources/snippet/de-DE.json` – Beispiel-Snippets.
+- `app/scripts/` – Platz für App Scripts.

--- a/shopware-basics/app-remote/README.md
+++ b/shopware-basics/app-remote/README.md
@@ -1,0 +1,38 @@
+# Remote App Skeleton
+
+## Was ist das?
+Dieses Skeleton liefert die Grundstruktur einer Shopware App mit Remote-Backend. Es enthält ein Manifest, Administration-Stub und Hinweise für Webhooks sowie App Scripts.
+
+## Typische Anwendungsfälle
+- SaaS-Integrationen mit Konfiguration in der Shopware-Administration.
+- Externe Services, die Bestellungen synchronisieren oder Daten anreichern.
+- Webhook-basierte Automatisierungen ohne Plugin-Installation.
+- Multi-Shop-Lösungen mit zentralem App-Backend.
+
+## Kurzes How-to
+1. Manifest in `app/manifest.xml` anpassen (App-Name, Domains, Permissions).
+2. Remote-Endpunkte implementieren (z. B. `/registration`, `/action`) – hier nur Platzhalter.
+3. Administration-Stub in `app/Resources/administration/main.js` erweitern, um Einstellungen zu pflegen.
+4. Snippets und Übersetzungen in `app/Resources/snippet/` ergänzen.
+5. App packen (`zip -r app.zip app/`) und über den Shopware App Manager installieren.
+6. Webhooks auf dem Remote-Server entgegennehmen und authentifizieren.
+
+## Wann einsetzen / Wann nicht
+**Wann einsetzen:** Für Integrationen, die außerhalb des Shopware-Servers laufen sollen oder Cloud-kompatibel sein müssen.
+**Wann nicht:** Wenn tiefe Shopware-Core-Erweiterungen oder Serverzugriff nötig sind – dann Plugin bauen.
+
+## Wo erweitern?
+- `app/manifest.xml` – Registrierung von Webhooks, Privileges, Module.
+- `app/Resources/administration/main.js` – UI für Einstellungen.
+- `app/Resources/snippet/` – Übersetzungen für die Admin-Oberfläche.
+- `app/scripts/` – App Scripts (z. B. zur Preisberechnung) ergänzen.
+
+## Weiterführend
+- Begriffe: App Lifecycle, App Webhooks, Permissions.
+- Suche nach `AppLifecycle` im Core.
+- Themen: App-Script Syntax, Signed Payloads.
+
+## Hinweise für Produktion
+- Remote-Server skalieren und Authentifizierung absichern (HMAC, TLS).
+- Logging und Monitoring für Webhook-Verarbeitung aufbauen.
+- Versionierung via App-Store Release-Prozess einplanen.

--- a/shopware-basics/app-remote/app/Resources/administration/main.js
+++ b/shopware-basics/app-remote/app/Resources/administration/main.js
@@ -1,0 +1,22 @@
+/* eslint-disable no-undef */
+Shopware.Module.register('acme-app-settings', {
+    type: 'plugin',
+    name: 'Acme App Settings',
+    title: 'acme-app.general.main',
+
+    routes: {
+        index: {
+            component: 'sw-settings-index',
+            path: 'index',
+        },
+    },
+
+    settingsItem: {
+        group: 'plugins',
+        to: 'acme.app.settings.index',
+        icon: 'default-basic-settings',
+        label: 'acme-app.general.menu',
+    },
+});
+
+// Projektteams fügen weitere Komponenten hinzu, um Remote-Konfigurationen zu speichern.

--- a/shopware-basics/app-remote/app/Resources/snippet/de-DE.json
+++ b/shopware-basics/app-remote/app/Resources/snippet/de-DE.json
@@ -1,0 +1,8 @@
+{
+    "acme-app": {
+        "general": {
+            "main": "Acme App Einstellungen",
+            "menu": "Acme App"
+        }
+    }
+}

--- a/shopware-basics/app-remote/app/manifest.xml
+++ b/shopware-basics/app-remote/app/manifest.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/Framework/App/Manifest/Schema/manifest-1.0.xsd">
+    <meta>
+        <name>AcmeSwBasicsApp</name>
+        <label>Acme Basics Remote App</label>
+        <version>1.0.0</version>
+        <license>proprietary</license>
+        <author>Acme</author>
+        <copyright>Acme</copyright>
+        <description>Skeleton für eine Remote App Integration.</description>
+    </meta>
+
+    <setup>
+        <registrationUrl>https://remote.example/register</registrationUrl>
+        <secret>[[REMOTE-SECRET]]</secret>
+        <modules>
+            <module name="acme-settings"
+                    source="Resources/administration/main.js"
+                    position="100"/>
+        </modules>
+    </setup>
+
+    <permissions>
+        <read>order:read</read>
+        <read>customer:read</read>
+    </permissions>
+
+    <webhooks>
+        <webhook name="acme-order-created"
+                 url="https://remote.example/webhook/order-created"
+                 event="checkout.order.placed"/>
+    </webhooks>
+</manifest>

--- a/shopware-basics/app-remote/app/scripts/README.md
+++ b/shopware-basics/app-remote/app/scripts/README.md
@@ -1,0 +1,5 @@
+# App Scripts Platzhalter
+
+- Hier App Script Dateien (z. B. `checkout/cart/script.twig`) platzieren.
+- Kommentare ergänzen, welche Ereignisse oder Hooks genutzt werden.
+- Remote-Ausführung beachten: Skripte laufen im Shop, Backend muss kompatibel sein.

--- a/shopware-basics/app-remote/skeleton.tree
+++ b/shopware-basics/app-remote/skeleton.tree
@@ -1,0 +1,15 @@
+```
+app-remote/
+├── README.md
+├── OVERVIEW.md
+├── skeleton.tree
+└── app
+    ├── Resources
+    │   ├── administration
+    │   │   └── main.js
+    │   └── snippet
+    │       └── de-DE.json
+    ├── manifest.xml
+    └── scripts
+        └── README.md
+```

--- a/shopware-basics/cms-experiences/OVERVIEW.md
+++ b/shopware-basics/cms-experiences/OVERVIEW.md
@@ -1,0 +1,9 @@
+# Übersicht: CMS Experiences Skeleton
+
+- `README.md` – Anleitung und Hinweise.
+- `skeleton.tree` – Struktur auf einen Blick.
+- `src/Resources/storefront/block/acme-simple-text/` – Twig-Templates für Block und Vorschau.
+- `src/Resources/app/administration/src/module/cms/elements/acme-simple-text/` – Vue-Modul zum Registrieren des Elements.
+- `cms.xml` – Block- und Element-Registrierung für Shopware.
+
+Weitere Anpassungen wie Assets oder Snippets können ergänzend abgelegt werden.

--- a/shopware-basics/cms-experiences/README.md
+++ b/shopware-basics/cms-experiences/README.md
@@ -1,0 +1,37 @@
+# Erlebniswelten Element Skeleton
+
+## Was ist das?
+Dieses Skeleton demonstriert, wie ein eigener CMS-Block mit einem einfachen Textelement für die Storefront erstellt wird. Es dient als Ausgangspunkt, um Marketing-Inhalte modular aufzubauen und über das Admin CMS zu pflegen.
+
+## Typische Anwendungsfälle
+- Inline-Textblöcke mit Custom Fields oder Snippets.
+- Landingpages mit wiederverwendbaren Textbausteinen.
+- Schnelle Prototypen für Kampagnen-Elemente.
+- Minimaler Einstieg für individuelle CMS-Komponenten.
+
+## Kurzes How-to
+1. Block- und Element-Dateien in `src/Resources/storefront/block/...` und `src/Resources/app/administration/...` anpassen.
+2. Registrierung in `src/Resources/app/administration/src/module/cms/elements/acme-simple-text/index.js` erweitern (Config/Fielde).
+3. CMS-Definition per `cms.xml` in das Plugin aufnehmen.
+4. Plugin installieren und aktivieren, danach Cache leeren (`bin/console cache:clear`).
+5. Im Admin unter Erlebniswelten den Block suchen, platzieren und Texte pflegen.
+6. Storefront prüfen, ggf. Theme kompilieren (`bin/console theme:compile`).
+
+## Wann einsetzen / Wann nicht
+**Wann einsetzen:** Für leichtgewichtige Inhaltsblöcke ohne komplexe Interaktionen. Gut geeignet für Marketing-Teams mit CMS-Fokus.
+**Wann nicht:** Bei umfangreichen Formularen, interaktiven Komponenten oder wenn Headless-only benötigt wird – dort besser dedizierte Vue/JS-Apps nutzen.
+
+## Wo erweitern?
+- `src/Resources/storefront/block/acme-simple-text/block.html.twig` – Ausgabe in der Storefront.
+- `src/Resources/app/administration/src/module/cms/elements/acme-simple-text` – Admin-Konfiguration.
+- `cms.xml` – Registrierung von Block und Element.
+
+## Weiterführend
+- Suche nach `cms-element` Komponenten im Core.
+- Twig Blocks: `component_cms_block_*` als Referenz.
+- Snippet Namespace: `cms.elements.*` für Übersetzungen.
+
+## Hinweise für Produktion
+- Responsive Verhalten testen und CSS erweitern.
+- Übersetzungen für alle Sprachen anlegen.
+- Deployment: CMS-Caches invalidieren und Erlebniswelten neu zuweisen.

--- a/shopware-basics/cms-experiences/skeleton.tree
+++ b/shopware-basics/cms-experiences/skeleton.tree
@@ -1,0 +1,23 @@
+```
+cms-experiences/
+├── README.md
+├── OVERVIEW.md
+├── skeleton.tree
+└── src
+    └── Resources
+        ├── app
+        │   └── administration
+        │       └── src
+        │           └── module
+        │               └── cms
+        │                   └── elements
+        │                       └── acme-simple-text
+        │                           └── index.js
+        ├── config
+        │   └── cms.xml
+        └── storefront
+            └── block
+                └── acme-simple-text
+                    ├── block.html.twig
+                    └── preview.html.twig
+```

--- a/shopware-basics/cms-experiences/src/Resources/app/administration/src/module/cms/elements/acme-simple-text/index.js
+++ b/shopware-basics/cms-experiences/src/Resources/app/administration/src/module/cms/elements/acme-simple-text/index.js
@@ -1,0 +1,23 @@
+const { Component, CMS } = Shopware;
+
+Component.register('sw-cms-el-acme-simple-text', {
+    template: '<div class="sw-cms-el-preview-acme-simple-text">[[Platzhalter: Vue Template ergänzen]]</div>',
+
+    created() {
+        // Hier kann später eine Initialisierung erfolgen, z. B. Laden von Defaults.
+    },
+});
+
+CMS.registerCmsElement({
+    name: 'acme-simple-text',
+    label: 'Acme Simple Text',
+    component: 'sw-cms-el-acme-simple-text',
+    previewComponent: 'sw-cms-el-acme-simple-text',
+    configComponent: 'sw-cms-el-config-text',
+    defaultConfig: {
+        content: {
+            source: 'static',
+            value: '[[Text per Admin setzen]]',
+        },
+    },
+});

--- a/shopware-basics/cms-experiences/src/Resources/config/cms.xml
+++ b/shopware-basics/cms-experiences/src/Resources/config/cms.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cms-elements xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/Content/Cms/Schema/cms-element-1.0.xsd">
+    <!-- Registriert das CMS-Element und verweist auf Twig/JS. Weitere Konfigurationen projektabhängig ergänzen. -->
+    <cms-element name="acme-simple-text"
+                 component="sw-cms-el-acme-simple-text"
+                 config-component="sw-cms-el-config-text"
+                 preview-component="sw-cms-el-acme-simple-text"
+                 default-compatibility="true">
+        <label>Acme Simple Text</label>
+        <category>text</category>
+        <icon>default-basic-stack-block</icon>
+        <slots>
+            <slot name="content"/>
+        </slots>
+    </cms-element>
+</cms-elements>

--- a/shopware-basics/cms-experiences/src/Resources/storefront/block/acme-simple-text/block.html.twig
+++ b/shopware-basics/cms-experiences/src/Resources/storefront/block/acme-simple-text/block.html.twig
@@ -1,0 +1,8 @@
+{% block cms_block_acme_simple_text %}
+    <div class="cms-block-acme-simple-text">
+        {# Projektteams ergänzen hier dynamische Ausgaben, z. B. Snippets oder Custom Fields. #}
+        <p class="cms-block-acme-simple-text__content">
+            {{ element.config.content.value|default('[[Platzhaltertext]]') }}
+        </p>
+    </div>
+{% endblock %}

--- a/shopware-basics/cms-experiences/src/Resources/storefront/block/acme-simple-text/preview.html.twig
+++ b/shopware-basics/cms-experiences/src/Resources/storefront/block/acme-simple-text/preview.html.twig
@@ -1,0 +1,4 @@
+<div class="cms-block-preview-acme-simple-text">
+    <strong>Acme Text-Element</strong>
+    <p>Vorschau des Inhalts – wird im Admin ersetzt.</p>
+</div>

--- a/shopware-basics/custom-fields/OVERVIEW.md
+++ b/shopware-basics/custom-fields/OVERVIEW.md
@@ -1,0 +1,8 @@
+# Übersicht: Custom Fields Skeleton
+
+- `README.md` – Nutzungskonzept und Ablauf.
+- `skeleton.tree` – Struktur des Skeletons zur schnellen Orientierung.
+- `src/Resources/config/custom_fields.xml` – registriert das Custom-Field-Set `acme_badge_set` mit Beispiel-Feldern.
+- `src/Resources/config/cms.xml` – kommentierter Platzhalter für die Nutzung der Custom Fields in CMS-Elementen.
+
+Weitere Dateien können nach Bedarf ergänzt werden, z. B. Migrationen oder zusätzliche Konfigurationen.

--- a/shopware-basics/custom-fields/README.md
+++ b/shopware-basics/custom-fields/README.md
@@ -1,0 +1,37 @@
+# Custom Fields & CMS Anbindung
+
+## Was ist das?
+Dieses Skeleton zeigt, wie ein Shopware-Plugin eigene Custom Fields registriert und sie in Erlebniswelten referenziert. Es dient als Ausgangspunkt, um zusätzliche Produktattribute wie ein `acme_badge`-Flag bereitzustellen und im Admin gepflegt nutzbar zu machen.
+
+## Typische Anwendungsfälle
+- Zusatzinformationen an Produkten oder Kategorien für Marketing-Labels.
+- Steuerung von CMS-Sichtbarkeit über boolesche Flags.
+- Anreicherungen für Rule Builder oder Flow Builder Bedingungen.
+- Austauschbare Hinweise für Export-/Integrations-Szenarien.
+
+## Kurzes How-to
+1. Plugin-Gerüst in `custom_fields/` in ein eigenständiges Plugin verschieben oder ein bestehendes erweitern.
+2. Custom-Field-Set in `src/Resources/config/custom_fields.xml` anpassen und mit gewünschten Entitäten verknüpfen.
+3. CMS-Zuordnung in `src/Resources/config/cms.xml` ergänzen, falls das Feld im Erlebniswelten-Layout benötigt wird.
+4. Plugin installieren (`bin/console plugin:install --activate`) und den Cache leeren (`bin/console cache:clear`).
+5. Im Admin unter Einstellungen → System → Custom Fields das Set prüfen und in Produkt-Layouts verwenden.
+6. Optional Regeln/Flows erstellen, die das Custom Field als Bedingung nutzen.
+
+## Wann einsetzen / Wann nicht
+**Wann einsetzen:** Wenn strukturierte Zusatzdaten ohne Core-Anpassungen benötigt werden. Ideal für einfache Booleans, Strings oder Selektoren, die im Admin gepflegt werden sollen.
+**Wann nicht:** Bei komplexen Relationen oder großen Datenmengen; hier lieber eigene Entities oder CMS-Blöcke nutzen. Keine Verwendung, wenn reine temporäre Berechnungen nötig sind.
+
+## Wo erweitern?
+- `src/Resources/config/custom_fields.xml` – Definition des Custom-Field-Sets und der Felder.
+- `src/Resources/config/cms.xml` – Verknüpfung der Custom Fields mit CMS-Komponenten.
+- `OVERVIEW.md` – Ergänzungen zu Abhängigkeiten oder Besonderheiten dokumentieren.
+
+## Weiterführend
+- Suchbegriff: "CustomFieldSetDefinition" im Core.
+- Ereignisse: `CustomFieldSetWrittenEvent` für Reaktionen.
+- Administration-Komponenten: `sw-field` für eigene Editoren.
+
+## Hinweise für Produktion
+- Migrationen und Deployments auf Staging prüfen, bevor Felder live geschaltet werden.
+- Tests für Datenintegrität und Default-Werte ergänzen.
+- Observability: Logging einbauen, falls Custom Fields externe Integrationen triggern.

--- a/shopware-basics/custom-fields/skeleton.tree
+++ b/shopware-basics/custom-fields/skeleton.tree
@@ -1,0 +1,11 @@
+```
+custom-fields/
+├── README.md
+├── OVERVIEW.md
+├── skeleton.tree
+└── src
+    └── Resources
+        └── config
+            ├── cms.xml
+            └── custom_fields.xml
+```

--- a/shopware-basics/custom-fields/src/Resources/config/cms.xml
+++ b/shopware-basics/custom-fields/src/Resources/config/cms.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cms-blocks xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/Content/Cms/Schema/cms-block-1.0.xsd">
+    <!-- Platzhalter-Block, der auf Custom Fields verweist. Projektteams fügen hier ein eigenes CMS-Element hinzu. -->
+    <cms-block name="acme-custom-field-hint"
+               category="text"
+               label="Acme Hinweis (Custom Field)">
+        <slots>
+            <slot type="text"
+                  slot="content">
+                <config>
+                    <!-- Shopware bietet über `mapped` Zugriff auf Custom Fields des Produktes. -->
+                    <content source="mapped">customFields.acme_badge_text</content>
+                </config>
+            </slot>
+        </slots>
+    </cms-block>
+</cms-blocks>

--- a/shopware-basics/custom-fields/src/Resources/config/custom_fields.xml
+++ b/shopware-basics/custom-fields/src/Resources/config/custom_fields.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<custom-fields xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/System/CustomField/Schema/custom_fields-1.0.xsd">
+    <!-- Dieses Set liefert ein boolesches und ein Text-Feld für Produkte. Projektteams erweitern hier um weitere Felder. -->
+    <custom-field-set name="acme_badge_set"
+                      label="Acme Zusatzbadge"
+                      position="1">
+        <related-entities>
+            <related-entity>product</related-entity>
+        </related-entities>
+
+        <custom-fields>
+            <custom-field name="acme_badge_active"
+                          type="bool"
+                          position="10">
+                <label>Badge aktiv</label>
+                <help-text>Setzt das Badge für Rule/Flow Builder.</help-text>
+            </custom-field>
+            <custom-field name="acme_badge_text"
+                          type="text"
+                          position="20">
+                <label>Badge Text</label>
+                <help-text>Kurzer Hinweis für Storefront-Komponenten.</help-text>
+            </custom-field>
+        </custom-fields>
+    </custom-field-set>
+</custom-fields>

--- a/shopware-basics/dal-entity/OVERVIEW.md
+++ b/shopware-basics/dal-entity/OVERVIEW.md
@@ -1,0 +1,9 @@
+# Übersicht: DAL Entity Skeleton
+
+- `README.md` – Funktionsumfang und Setup.
+- `skeleton.tree` – Strukturübersicht.
+- `src/Core/Content/Badge/BadgeDefinition.php` – Entity-Definition.
+- `src/Migration/Migration1700000001.php` – Datenbanktabelle `acme_badge`.
+- `src/Resources/config/services.xml` – Registriert Definition und Repository.
+
+Bei Bedarf Collections, Entities oder Aggregate-Definitionen ergänzen.

--- a/shopware-basics/dal-entity/README.md
+++ b/shopware-basics/dal-entity/README.md
@@ -1,0 +1,37 @@
+# DAL Entity Skeleton
+
+## Was ist das?
+Dieses Skeleton zeigt, wie eine eigene DAL-Entity namens "Badge" in Shopware registriert wird. Es umfasst Definition, Migration und Service-Registrierung als Grundlage für weitere Features.
+
+## Typische Anwendungsfälle
+- Zusätzliche Datenmodelle für Marketing- oder Content-Labels.
+- Referenzen von Produkten oder Kategorien auf eigene Entities.
+- Verwaltung von Metadaten für Integrationen.
+- Erweiterte CMS-Komponenten, die eigene Datenquellen benötigen.
+
+## Kurzes How-to
+1. Entity-Definition in `src/Core/Content/Badge/BadgeDefinition.php` anpassen.
+2. Felder und Beziehungen definieren, ggf. Aggregates ergänzen.
+3. Migration `src/Migration/Migration1700000001.php` aktualisieren.
+4. Services in `src/Resources/config/services.xml` registrieren (Repository, Definition, Collection).
+5. Plugin installieren, Migration ausführen, Cache leeren (`bin/console cache:clear`).
+6. Repository über Dependency Injection oder im Admin verwenden.
+
+## Wann einsetzen / Wann nicht
+**Wann einsetzen:** Wenn strukturierte Daten benötigt werden, die nicht in vorhandene Entities passen.
+**Wann nicht:** Für einfache Attribute – dort Custom Fields oder bestehende Relationen nutzen.
+
+## Wo erweitern?
+- `BadgeDefinition.php` – Entity-Felder, Beziehungen.
+- `Migration1700000001.php` – Tabellenschema.
+- `services.xml` – Registrierungen und Repository-Verwendung.
+
+## Weiterführend
+- Suche nach `EntityDefinition` im Core.
+- Begriffe: Collection, Entity, Definition, DAL.
+- Events: `EntityWrittenEvent` zur Reaktion auf Datenänderungen.
+
+## Hinweise für Produktion
+- Migrationsstrategie planen und Versionierung beachten.
+- Tests für Repository-Operationen schreiben.
+- Monitoring: Datenbankgröße und Konsistenz überwachen.

--- a/shopware-basics/dal-entity/skeleton.tree
+++ b/shopware-basics/dal-entity/skeleton.tree
@@ -1,0 +1,16 @@
+```
+dal-entity/
+├── README.md
+├── OVERVIEW.md
+├── skeleton.tree
+└── src
+    ├── Core
+    │   └── Content
+    │       └── Badge
+    │           └── BadgeDefinition.php
+    ├── Migration
+    │   └── Migration1700000001.php
+    └── Resources
+        └── config
+            └── services.xml
+```

--- a/shopware-basics/dal-entity/src/Core/Content/Badge/BadgeDefinition.php
+++ b/shopware-basics/dal-entity/src/Core/Content/Badge/BadgeDefinition.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acme\SwBasics\DalEntity\Core\Content\Badge;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+/**
+ * Definition der `acme_badge` Entity. Weitere Felder/Beziehungen projektabhängig ergänzen.
+ */
+class BadgeDefinition extends EntityDefinition
+{
+    public const ENTITY_NAME = 'acme_badge';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
+            (new StringField('name', 'name'))->addFlags(new Required()),
+            new StringField('description', 'description'),
+        ]);
+    }
+}

--- a/shopware-basics/dal-entity/src/Migration/Migration1700000001.php
+++ b/shopware-basics/dal-entity/src/Migration/Migration1700000001.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acme\SwBasics\DalEntity\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1700000001 extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1700000001;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement(
+            'CREATE TABLE IF NOT EXISTS `acme_badge` (
+                `id` BINARY(16) NOT NULL,
+                `name` VARCHAR(255) NOT NULL,
+                `description` LONGTEXT NULL,
+                `created_at` DATETIME(3) NOT NULL,
+                `updated_at` DATETIME(3) NULL,
+                PRIMARY KEY (`id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci'
+        );
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // Optional: Tabelle entfernen oder Spalten löschen, wenn erforderlich.
+    }
+}

--- a/shopware-basics/dal-entity/src/Resources/config/services.xml
+++ b/shopware-basics/dal-entity/src/Resources/config/services.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Acme\\SwBasics\\DalEntity\\Core\\Content\\Badge\\BadgeDefinition" public="true">
+            <tag name="shopware.entity.definition" entity="acme_badge"/>
+        </service>
+    </services>
+</container>

--- a/shopware-basics/events-subscriber-decorator/OVERVIEW.md
+++ b/shopware-basics/events-subscriber-decorator/OVERVIEW.md
@@ -1,0 +1,9 @@
+# Übersicht: Event Subscriber & Decorator Skeleton
+
+- `README.md` – Erläuterung der Erweiterung.
+- `skeleton.tree` – Struktur.
+- `src/Subscriber/CheckoutSubscriber.php` – Event-Subscriber.
+- `src/Decorator/LineItemServiceDecorator.php` – Decorator des LineItemService.
+- `src/Resources/config/services.xml` – Service-Registrierungen.
+
+Weitere Subscriber oder Decorators können in separaten Dateien ergänzt werden.

--- a/shopware-basics/events-subscriber-decorator/README.md
+++ b/shopware-basics/events-subscriber-decorator/README.md
@@ -1,0 +1,37 @@
+# Event Subscriber & Decorator Skeleton
+
+## Was ist das?
+Dieses Skeleton zeigt, wie Shopware-Events konsumiert und Services dekoriert werden. Der Beispiel-Subscriber reagiert auf Bestellereignisse, der Decorator erweitert einen bestehenden Service.
+
+## Typische Anwendungsfälle
+- Ergänzende Logs oder Notifications bei Order-Events.
+- Anpassung von Services ohne Core-Hack mittels Decorator.
+- Feature-Flags oder Konditionen vor/ nach Service-Aufrufen.
+- Integration externer Systeme bei bestimmten Ereignissen.
+
+## Kurzes How-to
+1. Subscriber in `src/Subscriber/CheckoutSubscriber.php` anpassen und gewünschte Events abonnieren.
+2. Decorator in `src/Decorator/LineItemServiceDecorator.php` anpassen (Dependencies erweitern).
+3. Services in `src/Resources/config/services.xml` registrieren, Prioritäten setzen.
+4. Plugin installieren/aktualisieren und Cache leeren (`bin/console cache:clear`).
+5. Ereignis testen (z. B. Testbestellung) und Logs überprüfen.
+6. Bei Bedarf weitere Services dekorieren oder Events hinzufügen.
+
+## Wann einsetzen / Wann nicht
+**Wann einsetzen:** Bei leichten Anpassungen bestehender Logik oder Event-basierten Integrationen.
+**Wann nicht:** Wenn tiefe Änderungen im Core benötigt werden – hier ggf. eigene Services oder DAL-Erweiterungen vorziehen.
+
+## Wo erweitern?
+- `CheckoutSubscriber.php` – Eventlogik.
+- `LineItemServiceDecorator.php` – Anpassungen an existierenden Services.
+- `services.xml` – Dekorationsreihenfolge und Tagging.
+
+## Weiterführend
+- Begriffe: EventDispatcher, Decorator Pattern, Service Tags.
+- Suche im Core nach `CheckoutOrderPlacedEvent` und `LineItemService`.
+- Themen: Synchrone/Asynchrone Event-Verarbeitung, Performance.
+
+## Hinweise für Produktion
+- Logging sparsam einsetzen, um Performance zu erhalten.
+- Fehlerhandling einplanen (Exceptions ggf. abfangen und monitoren).
+- Tests schreiben, um unerwartete Nebenwirkungen zu vermeiden.

--- a/shopware-basics/events-subscriber-decorator/skeleton.tree
+++ b/shopware-basics/events-subscriber-decorator/skeleton.tree
@@ -1,0 +1,14 @@
+```
+events-subscriber-decorator/
+├── README.md
+├── OVERVIEW.md
+├── skeleton.tree
+└── src
+    ├── Decorator
+    │   └── LineItemServiceDecorator.php
+    ├── Resources
+    │   └── config
+    │       └── services.xml
+    └── Subscriber
+        └── CheckoutSubscriber.php
+```

--- a/shopware-basics/events-subscriber-decorator/src/Decorator/LineItemServiceDecorator.php
+++ b/shopware-basics/events-subscriber-decorator/src/Decorator/LineItemServiceDecorator.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acme\SwBasics\EventsSubscriberDecorator\Decorator;
+
+use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
+use Shopware\Core\Checkout\Cart\LineItem\LineItemFactoryHandlerInterface;
+
+/**
+ * Decorator für den LineItemService. Ergänzt zusätzliche Prüfungen vor der Rückgabe.
+ */
+class LineItemServiceDecorator implements LineItemFactoryHandlerInterface
+{
+    public function __construct(private readonly LineItemFactoryHandlerInterface $inner)
+    {
+    }
+
+    public function supports(string $type): bool
+    {
+        return $this->inner->supports($type);
+    }
+
+    public function create(string $type, array $data, string $salesChannelContextId): LineItemCollection
+    {
+        // TODO: Daten vor dem Erzeugen validieren oder anreichern.
+        return $this->inner->create($type, $data, $salesChannelContextId);
+    }
+}

--- a/shopware-basics/events-subscriber-decorator/src/Resources/config/services.xml
+++ b/shopware-basics/events-subscriber-decorator/src/Resources/config/services.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Acme\\SwBasics\\EventsSubscriberDecorator\\Subscriber\\CheckoutSubscriber">
+            <argument type="service" id="logger"/>
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
+        <service id="Acme\\SwBasics\\EventsSubscriberDecorator\\Decorator\\LineItemServiceDecorator"
+                 decorates="Shopware\\Core\\Checkout\\Cart\\LineItem\\LineItemFactoryRegistry"
+                 decoration-priority="-10">
+            <argument type="service" id="Acme\\SwBasics\\EventsSubscriberDecorator\\Decorator\\LineItemServiceDecorator.inner"/>
+        </service>
+    </services>
+</container>

--- a/shopware-basics/events-subscriber-decorator/src/Subscriber/CheckoutSubscriber.php
+++ b/shopware-basics/events-subscriber-decorator/src/Subscriber/CheckoutSubscriber.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acme\SwBasics\EventsSubscriberDecorator\Subscriber;
+
+use Psr\Log\LoggerInterface;
+use Shopware\Core\Checkout\Order\Event\CheckoutOrderPlacedEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Reagiert auf Bestellabschlüsse. Hier können Notifications oder Integrationen ausgelöst werden.
+ */
+class CheckoutSubscriber implements EventSubscriberInterface
+{
+    public function __construct(private readonly LoggerInterface $logger)
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            CheckoutOrderPlacedEvent::class => 'onOrderPlaced',
+        ];
+    }
+
+    public function onOrderPlaced(CheckoutOrderPlacedEvent $event): void
+    {
+        // TODO: Integrationen/Benachrichtigungen ergänzen.
+        $this->logger->info('Acme CheckoutSubscriber ausgelöst.', [
+            'orderId' => $event->getOrder()->getId(),
+        ]);
+    }
+}

--- a/shopware-basics/headless-store-api/OVERVIEW.md
+++ b/shopware-basics/headless-store-api/OVERVIEW.md
@@ -1,0 +1,7 @@
+# Übersicht: Headless Store-API Skeleton
+
+- `README.md` – Leitfaden für Headless-Integrationen.
+- `skeleton.tree` – Strukturübersicht.
+- `examples/requests.http` – Beispielrequests für Produkt, Warenkorb, Checkout.
+
+Ergänzend können Environment-Beispiele oder Postman-Collections abgelegt werden.

--- a/shopware-basics/headless-store-api/README.md
+++ b/shopware-basics/headless-store-api/README.md
@@ -1,0 +1,37 @@
+# Headless Store-API Skeleton
+
+## Was ist das?
+Dieses Skeleton beschreibt die grundlegende Nutzung der Shopware Store-API in Headless-Szenarien. Es stellt dokumentierte Beispiel-Requests bereit und gibt Hinweise zu Authentifizierung, SEO und Performance.
+
+## Typische Anwendungsfälle
+- Headless-Frontend (Nuxt/Next) mit Store-API Backend.
+- Mobile Apps, die Warenkörbe und Checkout über APIs abwickeln.
+- Server-Side-Rendering-Layer für SEO-freundliche Auslieferung.
+- Integrationen mit CMS-Systemen, die Shopware-Daten anzeigen.
+
+## Kurzes How-to
+1. Zugriffstoken über `POST /store-api/oauth/token` beschaffen und in `examples/requests.http` eintragen.
+2. Produkt-Listing und Detail-Requests anpassen.
+3. Warenkorb-Workflow (create, add, checkout) anhand der Samples nachvollziehen.
+4. Backend-Ratenlimits und Caching planen.
+5. In der Headless-App die Endpunkte anbinden und Fehler-Handling ergänzen.
+6. Deployment: API-URLs als Environment-Variablen konfigurieren.
+
+## Wann einsetzen / Wann nicht
+**Wann einsetzen:** Wenn ein separates Frontend oder Device die Shop-Daten konsumiert und keine klassische Twig-Storefront benötigt wird.
+**Wann nicht:** Bei reinem Storefront-Projekt; dort CMS/Theme verwenden. Ebenso ungeeignet für reine Admin-Integrationen (Admin API nutzen).
+
+## Wo erweitern?
+- `examples/requests.http` – konkrete Request-Beispiele, Tokens und Payloads.
+- `OVERVIEW.md` – Zusatzhinweise zu Auth, Cache, SEO.
+- `README.md` – Dokumentation der Architekturentscheidungen.
+
+## Weiterführend
+- Begriffe: Store API, Sales Channel Context, Context Token.
+- Suche im Core nach `StoreApiRoute` für Erweiterungen.
+- Themen: Rate Limiting, SEO URL Endpoint, Webhook für Bestellungen.
+
+## Hinweise für Produktion
+- Token-Rotation und Refresh-Strategien planen.
+- Monitoring: API-Latenzen und Fehler (HTTP 429/500) loggen.
+- Tests: Contract-Tests mit Frontend und API durchführen.

--- a/shopware-basics/headless-store-api/examples/requests.http
+++ b/shopware-basics/headless-store-api/examples/requests.http
@@ -1,0 +1,59 @@
+### Produkt-Listing
+POST https://api.example.local/store-api/product-listing/acme-category
+accept: application/json
+sw-access-key: [[SALES-CHANNEL-KEY]]
+content-type: application/json
+
+{
+  "includes": {
+    "product": ["id", "name", "price"]
+  }
+}
+
+### Warenkorb erstellen
+POST https://api.example.local/store-api/checkout/cart
+accept: application/json
+sw-access-key: [[SALES-CHANNEL-KEY]]
+content-type: application/json
+
+{
+  "name": "acme-headless-cart"
+}
+
+### Warenkorb-Position hinzufügen
+POST https://api.example.local/store-api/checkout/cart/line-item
+accept: application/json
+sw-access-key: [[SALES-CHANNEL-KEY]]
+content-type: application/json
+sw-context-token: [[CONTEXT-TOKEN]]
+
+{
+  "type": "product",
+  "referencedId": "[[PRODUCT-ID]]",
+  "quantity": 1
+}
+
+### Checkout vorbereiten
+POST https://api.example.local/store-api/checkout/order
+accept: application/json
+sw-access-key: [[SALES-CHANNEL-KEY]]
+content-type: application/json
+sw-context-token: [[CONTEXT-TOKEN]]
+
+{
+  "customer": {
+    "email": "kundenmail@example.local",
+    "password": "[[OPTIONAL]]"
+  },
+  "paymentMethodId": "[[PAYMENT-ID]]",
+  "shippingMethodId": "[[SHIPPING-ID]]",
+  "billingAddress": {
+    "salutationId": "[[SALUTATION-ID]]",
+    "firstName": "Max",
+    "lastName": "Mustermann",
+    "street": "Musterweg 1",
+    "zipcode": "12345",
+    "city": "Musterstadt",
+    "countryId": "[[COUNTRY-ID]]"
+  }
+}

--- a/shopware-basics/headless-store-api/skeleton.tree
+++ b/shopware-basics/headless-store-api/skeleton.tree
@@ -1,0 +1,8 @@
+```
+headless-store-api/
+├── README.md
+├── OVERVIEW.md
+├── skeleton.tree
+└── examples
+    └── requests.http
+```

--- a/shopware-basics/integration-apis/OVERVIEW.md
+++ b/shopware-basics/integration-apis/OVERVIEW.md
@@ -1,0 +1,9 @@
+# Übersicht: Integration APIs Skeleton
+
+- `README.md` – Leitfaden für Admin API & Webhooks.
+- `skeleton.tree` – Struktur.
+- `src/Controller/WebhookController.php` – Controller-Stub.
+- `src/Resources/config/routes.xml` – Route für `/acme/webhook`.
+- `src/Resources/config/services.xml` – Service-Registrierung.
+
+Optionale Ergänzung: Command-Line Tools oder Clients für Admin API.

--- a/shopware-basics/integration-apis/README.md
+++ b/shopware-basics/integration-apis/README.md
@@ -1,0 +1,37 @@
+# Integration APIs Skeleton
+
+## Was ist das?
+Dieses Skeleton beschreibt die Nutzung der Admin API sowie das Empfangen von Webhooks in Shopware. Es bietet einen Controller-Stub und Dokumentation zu Authentifizierung und Idempotenz.
+
+## Typische Anwendungsfälle
+- Synchronisation externer Systeme via Admin API.
+- Empfang von Webhooks für Order/Customer Events.
+- Aufbau eigener Endpunkte zur Eventweiterleitung.
+- Verwaltung von API-Zugängen und Tokens.
+
+## Kurzes How-to
+1. Controller in `src/Controller/WebhookController.php` anpassen (HMAC-Validierung, Business-Logik).
+2. Route in `src/Resources/config/routes.xml` registrieren.
+3. Service-Definitionen in `src/Resources/config/services.xml` ergänzen.
+4. Admin API Credentials anlegen (`bin/console user:create` mit API-Rolle) und dokumentieren.
+5. Webhook-Absender konfigurieren (URLs, Secrets).
+6. Tests durchführen und Monitoring aufsetzen.
+
+## Wann einsetzen / Wann nicht
+**Wann einsetzen:** Für Integrationen mit externen Systemen, die Admin API benötigen oder Webhooks empfangen.
+**Wann nicht:** Für Storefront-only Datenzugriffe – dort Store-API verwenden.
+
+## Wo erweitern?
+- `WebhookController.php` – Business-Logik und Sicherheitsprüfungen.
+- `routes.xml` – Eigene Endpunkte.
+- `services.xml` – Zusätzliche Services/Handler.
+
+## Weiterführend
+- Begriffe: Admin API, Integration, Webhook Event.
+- Suche nach `WebhookDispatcher` im Core.
+- Themen: Idempotenz, Retry-Strategien, OAuth.
+
+## Hinweise für Produktion
+- Secrets sicher speichern und regelmäßig rotieren.
+- Request-Logging (z. B. Monolog Channel) aktivieren.
+- Rate Limits und Error Handling dokumentieren.

--- a/shopware-basics/integration-apis/skeleton.tree
+++ b/shopware-basics/integration-apis/skeleton.tree
@@ -1,0 +1,13 @@
+```
+integration-apis/
+├── README.md
+├── OVERVIEW.md
+├── skeleton.tree
+└── src
+    ├── Controller
+    │   └── WebhookController.php
+    └── Resources
+        └── config
+            ├── routes.xml
+            └── services.xml
+```

--- a/shopware-basics/integration-apis/src/Controller/WebhookController.php
+++ b/shopware-basics/integration-apis/src/Controller/WebhookController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acme\SwBasics\IntegrationApis\Controller;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * Empfängt Webhooks unter `/acme/webhook`. Projektteams ergänzen HMAC-Prüfungen und Verarbeitung.
+ */
+class WebhookController
+{
+    public function __construct(private readonly LoggerInterface $logger)
+    {
+    }
+
+    #[Route(path: '/acme/webhook', name: 'acme.webhook', defaults: ['csrf_protected' => false], methods: ['POST'])]
+    public function __invoke(Request $request): JsonResponse
+    {
+        // TODO: HMAC/Signature validieren und Payload verarbeiten.
+        $payload = $request->getContent();
+        $this->logger->info('Webhook empfangen.', ['payload' => $payload]);
+
+        return new JsonResponse(['status' => 'received']);
+    }
+}

--- a/shopware-basics/integration-apis/src/Resources/config/routes.xml
+++ b/shopware-basics/integration-apis/src/Resources/config/routes.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
+    <route id="acme.integration.webhook"
+           path="/acme/webhook"
+           controller="Acme\\SwBasics\\IntegrationApis\\Controller\\WebhookController"
+           methods="POST">
+        <default key="csrf_protected">false</default>
+    </route>
+</routes>

--- a/shopware-basics/integration-apis/src/Resources/config/services.xml
+++ b/shopware-basics/integration-apis/src/Resources/config/services.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Acme\\SwBasics\\IntegrationApis\\Controller\\WebhookController">
+            <argument type="service" id="logger"/>
+            <tag name="controller.service_arguments"/>
+        </service>
+    </services>
+</container>

--- a/shopware-basics/mq-scheduled-tasks/OVERVIEW.md
+++ b/shopware-basics/mq-scheduled-tasks/OVERVIEW.md
@@ -1,0 +1,9 @@
+# Übersicht: MQ & Scheduled Tasks Skeleton
+
+- `README.md` – Ablaufbeschreibung.
+- `skeleton.tree` – Struktur.
+- `src/ScheduledTask/AcmeHeartbeatTask.php` – Definition der Task.
+- `src/ScheduledTask/AcmeHeartbeatTaskHandler.php` – Ausführung.
+- `src/Message/AcmeDemoMessage.php` – Beispiel-Nachricht.
+- `src/Message/Handler/AcmeDemoMessageHandler.php` – MQ-Handler.
+- `src/Resources/config/services.xml` – Tags für Scheduled Task & Messenger.

--- a/shopware-basics/mq-scheduled-tasks/README.md
+++ b/shopware-basics/mq-scheduled-tasks/README.md
@@ -1,0 +1,38 @@
+# Message Queue & Scheduled Task Skeleton
+
+## Was ist das?
+Dieses Skeleton zeigt, wie wiederkehrende Aufgaben mit Scheduled Tasks geplant und Nachrichten über die Message Queue verarbeitet werden.
+
+## Typische Anwendungsfälle
+- Regelmäßige Health-Checks oder Synchronisationen.
+- Entkopplung zeitintensiver Prozesse über Queues.
+- Retry-Logik für externe API-Aufrufe.
+- Batch-Verarbeitung von Daten.
+
+## Kurzes How-to
+1. Scheduled Task in `src/ScheduledTask/AcmeHeartbeatTask.php` anpassen (Intervalle).
+2. Handler in `src/ScheduledTask/AcmeHeartbeatTaskHandler.php` mit Logik füllen.
+3. Message und Handler in `src/Message` ergänzen.
+4. Services in `src/Resources/config/services.xml` registrieren (Tags für Scheduler & Messenger).
+5. Message Queue Worker starten (`bin/console messenger:consume --time-limit=60`).
+6. Scheduled Task aktivieren (`bin/console scheduled-task:register`).
+
+## Wann einsetzen / Wann nicht
+**Wann einsetzen:** Für wiederkehrende, zeitverzögerte oder asynchrone Prozesse.
+**Wann nicht:** Bei trivialen Tasks, die synchron ablaufen können.
+
+## Wo erweitern?
+- `AcmeHeartbeatTask` – Intervalle und Name.
+- `AcmeHeartbeatTaskHandler` – Business-Logik der Scheduled Task.
+- `AcmeDemoMessage` & Handler – Verarbeitung asynchroner Jobs.
+- `services.xml` – Registrierung der Services.
+
+## Weiterführend
+- Begriffe: ScheduledTaskDefinition, Messenger Transport.
+- Suche nach `scheduled-task` im Core.
+- Themen: Retry-Strategy, Dead Letter Queue.
+
+## Hinweise für Produktion
+- Worker als Daemon betreiben und überwachen.
+- Logging/Monitoring für Task-Laufzeiten einrichten.
+- Idempotente Verarbeitungslogik sicherstellen.

--- a/shopware-basics/mq-scheduled-tasks/skeleton.tree
+++ b/shopware-basics/mq-scheduled-tasks/skeleton.tree
@@ -1,0 +1,17 @@
+```
+mq-scheduled-tasks/
+├── README.md
+├── OVERVIEW.md
+├── skeleton.tree
+└── src
+    ├── Message
+    │   ├── AcmeDemoMessage.php
+    │   └── Handler
+    │       └── AcmeDemoMessageHandler.php
+    ├── Resources
+    │   └── config
+    │       └── services.xml
+    └── ScheduledTask
+        ├── AcmeHeartbeatTask.php
+        └── AcmeHeartbeatTaskHandler.php
+```

--- a/shopware-basics/mq-scheduled-tasks/src/Message/AcmeDemoMessage.php
+++ b/shopware-basics/mq-scheduled-tasks/src/Message/AcmeDemoMessage.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acme\SwBasics\MqScheduledTasks\Message;
+
+/**
+ * Asynchrone Nachricht für Demo-Zwecke.
+ */
+class AcmeDemoMessage
+{
+    public function __construct(public readonly string $payload)
+    {
+    }
+}

--- a/shopware-basics/mq-scheduled-tasks/src/Message/Handler/AcmeDemoMessageHandler.php
+++ b/shopware-basics/mq-scheduled-tasks/src/Message/Handler/AcmeDemoMessageHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acme\SwBasics\MqScheduledTasks\Message\Handler;
+
+use Acme\SwBasics\MqScheduledTasks\Message\AcmeDemoMessage;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+
+/**
+ * Verarbeitet Demo-Messages aus der Queue.
+ */
+class AcmeDemoMessageHandler implements MessageHandlerInterface
+{
+    public function __construct(private readonly LoggerInterface $logger)
+    {
+    }
+
+    public function __invoke(AcmeDemoMessage $message): void
+    {
+        // TODO: Nachricht verarbeiten. Hier nur Logging.
+        $this->logger->info('AcmeDemoMessage verarbeitet.', [
+            'payload' => $message->payload,
+        ]);
+    }
+}

--- a/shopware-basics/mq-scheduled-tasks/src/Resources/config/services.xml
+++ b/shopware-basics/mq-scheduled-tasks/src/Resources/config/services.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Acme\\SwBasics\\MqScheduledTasks\\ScheduledTask\\AcmeHeartbeatTask" public="true">
+            <tag name="shopware.scheduled.task"/>
+        </service>
+
+        <service id="Acme\\SwBasics\\MqScheduledTasks\\ScheduledTask\\AcmeHeartbeatTaskHandler">
+            <argument type="service" id="messenger.bus.shopware"/>
+            <argument type="service" id="logger"/>
+            <tag name="shopware.scheduled.task.handler"/>
+        </service>
+
+        <service id="Acme\\SwBasics\\MqScheduledTasks\\Message\\AcmeDemoMessage"/>
+
+        <service id="Acme\\SwBasics\\MqScheduledTasks\\Message\\Handler\\AcmeDemoMessageHandler">
+            <argument type="service" id="logger"/>
+            <tag name="messenger.message_handler" bus="messenger.bus.shopware"/>
+        </service>
+    </services>
+</container>

--- a/shopware-basics/mq-scheduled-tasks/src/ScheduledTask/AcmeHeartbeatTask.php
+++ b/shopware-basics/mq-scheduled-tasks/src/ScheduledTask/AcmeHeartbeatTask.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acme\SwBasics\MqScheduledTasks\ScheduledTask;
+
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTask;
+
+/**
+ * Definiert eine wiederkehrende Task, die z. B. System-Health prüft.
+ */
+class AcmeHeartbeatTask extends ScheduledTask
+{
+    public static function getTaskName(): string
+    {
+        return 'acme.heartbeat';
+    }
+
+    public static function getDefaultInterval(): int
+    {
+        return 300; // alle 5 Minuten
+    }
+}

--- a/shopware-basics/mq-scheduled-tasks/src/ScheduledTask/AcmeHeartbeatTaskHandler.php
+++ b/shopware-basics/mq-scheduled-tasks/src/ScheduledTask/AcmeHeartbeatTaskHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acme\SwBasics\MqScheduledTasks\ScheduledTask;
+
+use Psr\Log\LoggerInterface;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Handler, der die Scheduled Task in die Queue legt.
+ */
+class AcmeHeartbeatTaskHandler extends ScheduledTaskHandler
+{
+    public function __construct(
+        MessageBusInterface $bus,
+        private readonly LoggerInterface $logger
+    ) {
+        parent::__construct($bus);
+    }
+
+    public static function getHandledMessages(): iterable
+    {
+        return [AcmeHeartbeatTask::class];
+    }
+
+    public function run(): void
+    {
+        $this->logger->info('AcmeHeartbeatTask wurde ausgelöst.');
+        parent::run();
+    }
+}

--- a/shopware-basics/payment-handler/OVERVIEW.md
+++ b/shopware-basics/payment-handler/OVERVIEW.md
@@ -1,0 +1,7 @@
+# Übersicht: Payment Handler Skeleton
+
+- `README.md` – Hinweise und Setup.
+- `skeleton.tree` – Strukturübersicht.
+- `src/Payment/AcmePaymentHandler.php` – Handler-Implementierung.
+- `src/Resources/config/payment-method.xml` – Payment-Methode.
+- `src/Resources/config/services.xml` – Service-Definition.

--- a/shopware-basics/payment-handler/README.md
+++ b/shopware-basics/payment-handler/README.md
@@ -1,0 +1,37 @@
+# Payment Handler Skeleton
+
+## Was ist das?
+Dieses Skeleton liefert einen asynchronen Payment Handler für Shopware. Er zeigt die notwendigen Methoden und Konfigurationsdateien, um Zahlungsanbieter anzubinden.
+
+## Typische Anwendungsfälle
+- Anbindung eines externen Zahlungsdienstleisters mit Redirect-Flow.
+- Verarbeitung von Capture/Refund über asynchrone Workflows.
+- Logging und Statusverwaltung für Zahlungen.
+- Erweiterung bestehender Payment-Integrationen.
+
+## Kurzes How-to
+1. Handler in `src/Payment/AcmePaymentHandler.php` implementieren (pay/finalize/capture/refund).
+2. Payment-Method Definition in `src/Resources/config/payment-method.xml` anpassen.
+3. Service in `src/Resources/config/services.xml` registrieren.
+4. Plugin installieren, Payment-Methode aktivieren (`bin/console payment:method:activate`).
+5. Zahlungsanbieter konfigurieren (API-Keys, Redirect-URLs).
+6. Testbestellungen durchführen und Logs überwachen.
+
+## Wann einsetzen / Wann nicht
+**Wann einsetzen:** Wenn ein eigener oder externer Zahlungsdienstleister eingebunden werden muss.
+**Wann nicht:** Bei Nutzung bereits existierender Zahlungsplugins oder wenn kein Redirect/Asynchronität benötigt wird.
+
+## Wo erweitern?
+- `AcmePaymentHandler.php` – Implementierung der Zahlungslogik.
+- `payment-method.xml` – Definition der Payment-Methode.
+- `services.xml` – Handler-Registrierung und Abhängigkeiten.
+
+## Weiterführend
+- Begriffe: `AsynchronousPaymentHandlerInterface`, `PaymentTransactionStruct`.
+- Suche nach `AsyncPaymentTransactionStateHandler` im Core.
+- Themen: Capture, Refund, Webhook-Rückmeldungen.
+
+## Hinweise für Produktion
+- API-Keys sicher speichern und Secrets rotieren.
+- Error-Handling und Retry-Strategien implementieren.
+- Tests für Zahlungsabläufe (Unit/Integration) erstellen.

--- a/shopware-basics/payment-handler/skeleton.tree
+++ b/shopware-basics/payment-handler/skeleton.tree
@@ -1,0 +1,13 @@
+```
+payment-handler/
+├── README.md
+├── OVERVIEW.md
+├── skeleton.tree
+└── src
+    ├── Payment
+    │   └── AcmePaymentHandler.php
+    └── Resources
+        └── config
+            ├── payment-method.xml
+            └── services.xml
+```

--- a/shopware-basics/payment-handler/src/Payment/AcmePaymentHandler.php
+++ b/shopware-basics/payment-handler/src/Payment/AcmePaymentHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acme\SwBasics\PaymentHandler\Payment;
+
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentTransactionStruct;
+use Shopware\Core\Framework\Context;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Asynchroner Payment Handler mit Platzhaltern für Redirect/Capture/Refund.
+ */
+class AcmePaymentHandler implements AsynchronousPaymentHandlerInterface
+{
+    public function pay(Request $request, PaymentTransactionStruct $transaction, Context $context): RedirectResponse
+    {
+        // TODO: Redirect-URL des PSP generieren.
+        return new RedirectResponse('https://payment.example/redirect');
+    }
+
+    public function finalize(Request $request, PaymentTransactionStruct $transaction, Context $context): void
+    {
+        // TODO: PSP-Rückgabe auswerten und Status setzen.
+    }
+
+    public function capture(Context $context, PaymentTransactionStruct $transaction, ?Request $request = null): void
+    {
+        // TODO: Capture API des PSP aufrufen.
+    }
+
+    public function refund(Context $context, PaymentTransactionStruct $transaction, ?Request $request = null): void
+    {
+        // TODO: Refund API des PSP aufrufen.
+    }
+}

--- a/shopware-basics/payment-handler/src/Resources/config/payment-method.xml
+++ b/shopware-basics/payment-handler/src/Resources/config/payment-method.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<payment-methods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/Checkout/Payment/Schema/payment-method-1.0.xsd">
+    <payment-method id="acme_payment"
+                    name="Acme Pay"
+                    position="100"
+                    plugin="AcmeSwBasicsPaymentHandler"
+                    handler="Acme\\SwBasics\\PaymentHandler\\Payment\\AcmePaymentHandler">
+        <description>Skeleton für asynchrone Zahlungen.</description>
+        <translations>
+            <translation locale="de-DE"
+                         name="Acme Pay"
+                         description="Skeleton für asynchrone Zahlungen."/>
+        </translations>
+    </payment-method>
+</payment-methods>

--- a/shopware-basics/payment-handler/src/Resources/config/services.xml
+++ b/shopware-basics/payment-handler/src/Resources/config/services.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Acme\\SwBasics\\PaymentHandler\\Payment\\AcmePaymentHandler">
+            <tag name="shopware.payment.method.handler" handler="Acme\\SwBasics\\PaymentHandler\\Payment\\AcmePaymentHandler"/>
+        </service>
+    </services>
+</container>

--- a/shopware-basics/plugin-core/OVERVIEW.md
+++ b/shopware-basics/plugin-core/OVERVIEW.md
@@ -1,0 +1,9 @@
+# Übersicht: Core Plugin Skeleton
+
+- `README.md` – Dokumentation und Setup.
+- `composer.json` – Paketdefinition, Autoload.
+- `src/AcmeSwBasicsCore.php` – Plugin-Klasse.
+- `src/Resources/config/services.xml` – Service-Definitionen.
+- `src/Migration/Migration1700000000.php` – Beispielmigration.
+- `src/Service/DemoService.php` – Service-Stub.
+- `skeleton.tree` – Strukturüberblick.

--- a/shopware-basics/plugin-core/README.md
+++ b/shopware-basics/plugin-core/README.md
@@ -1,0 +1,38 @@
+# Core Plugin Skeleton
+
+## Was ist das?
+Dieses Skeleton zeigt die Grundstruktur eines klassischen Shopware-Plugins mit Services, Migration und Konfiguration. Es dient als Ausgangspunkt für serverseitige Erweiterungen.
+
+## Typische Anwendungsfälle
+- Backend-Services, die Daten verarbeiten oder APIs anbinden.
+- Registrieren von Events, Subscribern oder Cronjobs.
+- DAL-Erweiterungen und Migrationslogik.
+- Konfigurierbare Business-Prozesse innerhalb von Shopware.
+
+## Kurzes How-to
+1. `composer.json` anpassen und Autoload sicherstellen.
+2. Plugin-Klasse `src/AcmeSwBasicsCore.php` erweitern (Install/Update Hooks).
+3. Services in `src/Resources/config/services.xml` registrieren.
+4. Migrationen (z. B. `Migration1700000000.php`) anpassen und neue Tabellen/Spalten definieren.
+5. Plugin installieren (`bin/console plugin:install --activate AcmeSwBasicsCore`) und Migrationen ausführen (`bin/console database:migrate`).
+6. Cache leeren (`bin/console cache:clear`) und Funktionen testen.
+
+## Wann einsetzen / Wann nicht
+**Wann einsetzen:** Wenn tiefgreifende Serverlogik benötigt wird oder wenn Cloud-Einschränkungen irrelevant sind.
+**Wann nicht:** Für reine Frontend-/Headless-Anpassungen oder Cloud-Projekte ohne Zugriff auf das Dateisystem – dort Apps bevorzugen.
+
+## Wo erweitern?
+- `src/Resources/config/services.xml` – Services/Subscriber deklarieren.
+- `src/Service/DemoService.php` – Beispiel-Service als Einstiegspunkt.
+- `src/Migration/Migration1700000000.php` – Datenbankschema erweitern.
+- `src/AcmeSwBasicsCore.php` – Plugin-Lebenszyklus.
+
+## Weiterführend
+- Begriffe: Plugin Lifecycle, Dependency Injection Container, DAL.
+- Suche im Core nach `PluginLifecycleService` und `ContainerCompiler`.
+- Events: `KernelEvents::REQUEST`, `OrderPlacedEvent` etc.
+
+## Hinweise für Produktion
+- Migrationen vor Deployments auf Testumgebung prüfen.
+- Unit-/Integrationstests für Services schreiben.
+- Logging/Monitoring (z. B. Monolog Channels) konfigurieren.

--- a/shopware-basics/plugin-core/composer.json
+++ b/shopware-basics/plugin-core/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "acme/swbasics-plugin",
+    "type": "shopware-platform-plugin",
+    "description": "Skeleton Plugin für Shopware Core Erweiterungen",
+    "license": "proprietary",
+    "autoload": {
+        "psr-4": {
+            "Acme\\SwBasics\\PluginCore\\": "src/"
+        }
+    }
+}

--- a/shopware-basics/plugin-core/skeleton.tree
+++ b/shopware-basics/plugin-core/skeleton.tree
@@ -1,0 +1,16 @@
+```
+plugin-core/
+├── README.md
+├── OVERVIEW.md
+├── composer.json
+├── skeleton.tree
+└── src
+    ├── AcmeSwBasicsCore.php
+    ├── Migration
+    │   └── Migration1700000000.php
+    ├── Resources
+    │   └── config
+    │       └── services.xml
+    └── Service
+        └── DemoService.php
+```

--- a/shopware-basics/plugin-core/src/AcmeSwBasicsCore.php
+++ b/shopware-basics/plugin-core/src/AcmeSwBasicsCore.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acme\SwBasics\PluginCore;
+
+use Shopware\Core\Framework\Plugin;
+
+/**
+ * Einstiegspunkt des Plugins. Projektteams ergänzen hier Install-/Update-Logik.
+ */
+class AcmeSwBasicsCore extends Plugin
+{
+}

--- a/shopware-basics/plugin-core/src/Migration/Migration1700000000.php
+++ b/shopware-basics/plugin-core/src/Migration/Migration1700000000.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acme\SwBasics\PluginCore\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * Lege eine einfache Demo-Tabelle an. Schema nach Bedarf erweitern.
+ */
+class Migration1700000000 extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1700000000;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement(
+            'CREATE TABLE IF NOT EXISTS `acme_demo` (
+                `id` BINARY(16) NOT NULL,
+                `created_at` DATETIME(3) NOT NULL,
+                `updated_at` DATETIME(3) NULL,
+                PRIMARY KEY (`id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci'
+        );
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // Destructive Änderungen (DROP) hier dokumentieren.
+    }
+}

--- a/shopware-basics/plugin-core/src/Resources/config/services.xml
+++ b/shopware-basics/plugin-core/src/Resources/config/services.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Acme\\SwBasics\\PluginCore\\Service\\DemoService">
+            <argument type="service" id="logger"/>
+            <tag name="monolog.logger" channel="acme_plugin"/>
+        </service>
+    </services>
+</container>

--- a/shopware-basics/plugin-core/src/Service/DemoService.php
+++ b/shopware-basics/plugin-core/src/Service/DemoService.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acme\SwBasics\PluginCore\Service;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Beispiel-Service: Projekte implementieren hier reale Business-Logik.
+ */
+class DemoService
+{
+    public function __construct(private readonly LoggerInterface $logger)
+    {
+    }
+
+    public function handle(): void
+    {
+        // TODO: Eigene Logik ergänzen (z. B. API-Call). Aktuell nur Hinweis im Log.
+        $this->logger->info('Acme DemoService wurde aufgerufen.');
+    }
+}

--- a/shopware-basics/rule-flow-builder/OVERVIEW.md
+++ b/shopware-basics/rule-flow-builder/OVERVIEW.md
@@ -1,0 +1,9 @@
+# Übersicht: Rule & Flow Builder Skeleton
+
+- `README.md` – Erläuterungen zu Regeln und Flows.
+- `skeleton.tree` – Struktur der Ressourcen.
+- `src/Resources/flow/rules/` – Ablageort für Rule Builder Exporte.
+- `src/Resources/flow/flows/` – Ablageort für Flow Builder Exporte.
+- `src/Docs/examples.md` – dokumentiert Beispielbedingungen und Importtipps.
+
+Beim Import auf IDs achten: Shopware generiert GUIDs, die projektspezifisch ersetzt werden müssen.

--- a/shopware-basics/rule-flow-builder/README.md
+++ b/shopware-basics/rule-flow-builder/README.md
@@ -1,0 +1,37 @@
+# Rule & Flow Builder Skeleton
+
+## Was ist das?
+Dieses Skeleton skizziert, wie eine Preisregel im Rule Builder vorbereitet wird und wie ein Flow Builder Flow für eine Bestellbestätigung mit zusätzlichem Header strukturiert sein kann. Es dient als Startpunkt für Teams, die Regeln und Flows versionierbar verwalten möchten.
+
+## Typische Anwendungsfälle
+- Rabatt- oder Versandregeln basierend auf Custom Fields.
+- Flow-gesteuerte E-Mail-Anreicherungen nach Bestellungen.
+- Automatisierte interne Benachrichtigungen bei speziellen Warenkörben.
+- Export- oder Tagging-Flows zur Weiterverarbeitung.
+
+## Kurzes How-to
+1. Rule Builder Export in `src/Resources/flow/rules/` ablegen (JSON/YAML, Platzhalter in README kommentiert).
+2. Flow Builder Definition in `src/Resources/flow/flows/` importierbar vorbereiten.
+3. Projektinterne IDs und Bedingungen in `src/Docs/examples.md` dokumentieren.
+4. Plugin/Bundle deployen und im Admin unter Rule Builder bzw. Flow Builder importieren.
+5. Aktivieren, Testbestellung durchführen und Logging prüfen.
+6. Cache leeren (`bin/console cache:clear`) und Regel-/Flow-Status überwachen.
+
+## Wann einsetzen / Wann nicht
+**Wann einsetzen:** Bei konfigurativen Prozessen, die Shopware-nativ mit Rules und Flows abbildbar sind, z. B. Marketing-Automationen.
+**Wann nicht:** Bei hochkomplexen Workflows mit externen Systemen oder umfangreicher Programmierung – hier eigene Services und Queue-Verarbeitung bevorzugen.
+
+## Wo erweitern?
+- `src/Resources/flow/rules/` – Export-Dateien für Rule Builder.
+- `src/Resources/flow/flows/` – Flow-Definitionen mit Sequenzen.
+- `src/Docs/examples.md` – Dokumentation von Variablen, Bedingungen und Screenshots.
+
+## Weiterführend
+- Suchbegriff: "RuleConditions" im Core.
+- Flow Actions: `SendMailAction` und `LogAction` als Referenz.
+- Events: `OrderPlacedEvent` für Flow Trigger.
+
+## Hinweise für Produktion
+- Regeln und Flows versionieren, IDs und Namespaces konsistent halten.
+- Automatisierte Tests für regelbasierte Preise durchrechnen.
+- Observability: Flow-Logs im Admin prüfen und ggf. an Monitoring anbinden.

--- a/shopware-basics/rule-flow-builder/skeleton.tree
+++ b/shopware-basics/rule-flow-builder/skeleton.tree
@@ -1,0 +1,13 @@
+```
+rule-flow-builder/
+├── README.md
+├── OVERVIEW.md
+├── skeleton.tree
+└── src
+    ├── Docs
+    │   └── examples.md
+    └── Resources
+        └── flow
+            ├── flows
+            └── rules
+```

--- a/shopware-basics/rule-flow-builder/src/Docs/examples.md
+++ b/shopware-basics/rule-flow-builder/src/Docs/examples.md
@@ -1,0 +1,10 @@
+# Beispiel-Notizen für Rules & Flows
+
+- Rule Builder: Beispiel-Preisregel `acme_price_over_100`, Bedingung (Pseudo)
+  ```text
+  cart.amount.total > 100 && customer.customFields.acme_badge_active == true
+  ```
+- Flow Builder: Exportierte JSON-Datei hier ablegen (`src/Resources/flow/flows/order-confirmation.json`).
+- Reminder: Screenshots des Flow-Aufbaus (Trigger: `order.placed`, Aktion: `send.mail`) an `docs/` anhängen.
+- Import: `bin/console workflow:import` existiert nicht – Nutzung über Admin UI. Hinweise hier dokumentieren.
+- IDs: UUIDs beim Import prüfen, ggf. mit Deploy-Skripten ersetzen.

--- a/shopware-basics/rule-flow-builder/src/Resources/flow/flows/.gitkeep
+++ b/shopware-basics/rule-flow-builder/src/Resources/flow/flows/.gitkeep
@@ -1,0 +1,1 @@
+# Ablage für Flow-Builder Exporte (JSON/YAML). Beim Projektstart Flow-Dateien hier platzieren.

--- a/shopware-basics/rule-flow-builder/src/Resources/flow/rules/.gitkeep
+++ b/shopware-basics/rule-flow-builder/src/Resources/flow/rules/.gitkeep
@@ -1,0 +1,1 @@
+# Ablage für Rule-Builder Exporte (JSON). IDs und Labels projektspezifisch pflegen.

--- a/shopware-basics/security-release/ADR-0001-release-strategy.md
+++ b/shopware-basics/security-release/ADR-0001-release-strategy.md
@@ -1,0 +1,19 @@
+# ADR-0001: Release-Strategie
+
+## Status
+Entwurf – anpassen und finalisieren, sobald der Prozess abgestimmt ist.
+
+## Kontext
+Wir veröffentlichen regelmäßig Shopware-Erweiterungen und benötigen einen konsistenten Prozess für Releases, inklusive SemVer, Sicherheitsprüfung und Kommunikationsplan.
+
+## Entscheidung
+- Wir folgen SemVer (MAJOR.MINOR.PATCH).
+- Sicherheitsrelevante Fixes erhalten Patch-Release mit Hotfix-Prozess.
+- Release-Candidate Phase mit manuellen Tests und automatisierten Pipelines.
+- Changelog wird pro Release gepflegt und mit Store-Eintrag synchronisiert.
+
+## Konsequenzen
+- Team muss Feature-Flags und Migrationspfade planen.
+- Automatisierte Tests (Unit, Integration, Smoke) sind Pflicht vor Release.
+- Sicherheitsreview (Dependency-Check, Secrets, Permissions) vor Freigabe.
+- Rollback-Plan und Monitoring aktiv halten.

--- a/shopware-basics/security-release/OVERVIEW.md
+++ b/shopware-basics/security-release/OVERVIEW.md
@@ -1,0 +1,7 @@
+# Übersicht: Security & Release Skeleton
+
+- `README.md` – Leitfaden für Release- und Security-Prozesse.
+- `skeleton.tree` – Struktur.
+- `ADR-0001-release-strategy.md` – Entscheidungsdokument für Release-Strategie.
+
+Weitere ADRs oder Checklisten können hinzugefügt werden.

--- a/shopware-basics/security-release/README.md
+++ b/shopware-basics/security-release/README.md
@@ -1,0 +1,37 @@
+# Security & Release Skeleton
+
+## Was ist das?
+Dieses Skeleton bündelt Best Practices für Releases, Versionierung und Security-Checks von Shopware-Erweiterungen. Es enthält eine ADR-Vorlage und Checklisten.
+
+## Typische Anwendungsfälle
+- Planung einer neuen Plugin-Version.
+- Sicherheitsüberprüfung vor Store-Release.
+- Dokumentation von Breaking Changes.
+- Abstimmung zwischen Dev, QA und Ops.
+
+## Kurzes How-to
+1. Release-Plan erstellen und in `ADR-0001-release-strategy.md` festhalten.
+2. SemVer-Entscheidungen dokumentieren (Major/Minor/Patch).
+3. Sicherheits-Checkliste abarbeiten (Dependencies, Secrets, Permissions).
+4. Tests ausführen (Unit, Integration, E2E) und Ergebnisse dokumentieren.
+5. Changelog vorbereiten und Store-Metadaten aktualisieren.
+6. Deployment-Plan mit Rollback definieren.
+
+## Wann einsetzen / Wann nicht
+**Wann einsetzen:** Vor jedem offiziellen Release oder sicherheitsrelevanten Patch.
+**Wann nicht:** Für interne Prototypen ohne Veröffentlichung – dort genügt vereinfachte Dokumentation.
+
+## Wo erweitern?
+- `ADR-0001-release-strategy.md` – Architekturentscheidungen.
+- `README.md` – Checklisten erweitern.
+- Weitere ADRs hinzufügen (z. B. Security Policy).
+
+## Weiterführend
+- Begriffe: SemVer, Security Advisory, Store Submission.
+- Suche nach `ReleaseService` im Core.
+- Themen: Code Signing, App Store Anforderungen.
+
+## Hinweise für Produktion
+- Migrationslisten doppelt prüfen, Rollback-Plan parat haben.
+- CVEs beobachten und Dependencies regelmäßig aktualisieren.
+- Security-Tests (z. B. SAST/DAST) automatisieren.

--- a/shopware-basics/security-release/skeleton.tree
+++ b/shopware-basics/security-release/skeleton.tree
@@ -1,0 +1,7 @@
+```
+security-release/
+├── README.md
+├── OVERVIEW.md
+├── ADR-0001-release-strategy.md
+└── skeleton.tree
+```

--- a/shopware-basics/shipping-basics/OVERVIEW.md
+++ b/shopware-basics/shipping-basics/OVERVIEW.md
@@ -1,0 +1,7 @@
+# Übersicht: Versand Basics Skeleton
+
+- `README.md` – Versandkonzept und Hinweise.
+- `skeleton.tree` – Struktur.
+- `src/Service/ShippingCostNoteService.php` – Service für Versandhinweise.
+
+Erweitern Sie die Dokumentation um konkrete Rule-Builder-Ausdrücke und Preislogiken.

--- a/shopware-basics/shipping-basics/README.md
+++ b/shopware-basics/shipping-basics/README.md
@@ -1,0 +1,37 @@
+# Versand Basics Skeleton
+
+## Was ist das?
+Dieses Skeleton bietet Dokumentation und einen Service-Stub rund um Versandarten in Shopware. Es zeigt, wie Regeln und Hinweise eingebunden werden können.
+
+## Typische Anwendungsfälle
+- Versandarten über Rule Builder differenzieren.
+- Zusätzliche Hinweise für Kunden generieren.
+- Versandlogik in Services kapseln.
+- Integration externer Versanddienstleister vorbereiten.
+
+## Kurzes How-to
+1. Versandarten im Admin konfigurieren (Einstellungen → Versand). Regeln und Preise dort pflegen.
+2. `src/Service/ShippingCostNoteService.php` nutzen, um Hinweise dynamisch zu erzeugen.
+3. Rule-Builder-Regeln dokumentieren (z. B. Gewicht, Custom Fields).
+4. Service per Dependency Injection einbinden und in Storefront oder API nutzen.
+5. Cache leeren (`bin/console cache:clear`) nach Anpassungen.
+6. Versandkostenberechnungen testen (verschiedene Warenkörbe).
+
+## Wann einsetzen / Wann nicht
+**Wann einsetzen:** Wenn Versandkonfigurationen dokumentiert und leicht erweitert werden sollen.
+**Wann nicht:** Für komplexe, eigene Versandberechnungen – dort dedizierte Calculator-Services implementieren.
+
+## Wo erweitern?
+- `ShippingCostNoteService.php` – Logik für Hinweise oder Aufpreise.
+- `OVERVIEW.md` – Dokumentation von Regeln und Szenarien.
+- `README.md` – Ergänzende Prozesse (z. B. Zoll).
+
+## Weiterführend
+- Begriffe: Versandart, Rule Builder, Delivery Time.
+- Suche im Core nach `ShippingMethodEntity`.
+- Themen: Rule-Matching, Checkout Validatoren.
+
+## Hinweise für Produktion
+- Versandkosten regelmäßig prüfen (Preisänderungen, Carrier-Updates).
+- Monitoring für Fehlerraten beim Checkout.
+- Tests für Regelkombinationen (z. B. via Behat/Cypress) einplanen.

--- a/shopware-basics/shipping-basics/skeleton.tree
+++ b/shopware-basics/shipping-basics/skeleton.tree
@@ -1,0 +1,9 @@
+```
+shipping-basics/
+├── README.md
+├── OVERVIEW.md
+├── skeleton.tree
+└── src
+    └── Service
+        └── ShippingCostNoteService.php
+```

--- a/shopware-basics/shipping-basics/src/Service/ShippingCostNoteService.php
+++ b/shopware-basics/shipping-basics/src/Service/ShippingCostNoteService.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acme\SwBasics\ShippingBasics\Service;
+
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Framework\Context;
+
+/**
+ * Liefert Zusatzhinweise zu Versandarten (z. B. basierend auf Rules oder Gewichten).
+ */
+class ShippingCostNoteService
+{
+    public function buildNote(Cart $cart, Context $context): string
+    {
+        // TODO: Versandart-Informationen ermitteln und Hinweis generieren.
+        return 'Versandhinweis Platzhalter';
+    }
+}

--- a/shopware-basics/state-machine/OVERVIEW.md
+++ b/shopware-basics/state-machine/OVERVIEW.md
@@ -1,0 +1,8 @@
+# Übersicht: State Machine Skeleton
+
+- `README.md` – Erläuterung und ASCII-Diagramm.
+- `skeleton.tree` – Struktur.
+- `src/Resources/state-machine/acme_order_state.xml` – State Machine Definition.
+- `src/Subscriber/StateTransitionSubscriber.php` – Event-Listener für Transitionen.
+
+Weitere Transitionen oder Guards können in zusätzlichen Services abgebildet werden.

--- a/shopware-basics/state-machine/README.md
+++ b/shopware-basics/state-machine/README.md
@@ -1,0 +1,46 @@
+# State Machine Skeleton
+
+## Was ist das?
+Dieses Skeleton demonstriert, wie eine eigene Zustandsmaschine für Bestellungen angelegt und um Transition-Logik ergänzt wird. Es bietet eine XML-Definition sowie einen Subscriber.
+
+ASCII-Diagramm:
+```
+[created] --(prüfen)--> [review]
+   |                        |
+   +--(stornieren)--> [cancelled]
+   |
+   +--(freigeben)--> [completed]
+```
+
+## Typische Anwendungsfälle
+- Individuelle Order- oder Lieferprozesse modellieren.
+- Übergänge mit zusätzlichen Prüfungen versehen.
+- Interne Freigabeprozesse abbilden.
+- Automatisierte Benachrichtigungen bei Statusänderungen.
+
+## Kurzes How-to
+1. XML in `src/Resources/state-machine/acme_order_state.xml` anpassen (States/Transitions).
+2. Subscriber in `src/Subscriber/StateTransitionSubscriber.php` erweitern (Validierungen, Logs).
+3. Plugin installieren/aktualisieren und State Machine importieren (`bin/console state-machine:dump` zum Prüfen).
+4. Cache leeren (`bin/console cache:clear`).
+5. State Machine per Admin oder API den relevanten Entitäten zuweisen.
+6. Übergänge testen und Monitoring prüfen.
+
+## Wann einsetzen / Wann nicht
+**Wann einsetzen:** Für strukturierte Prozesse, die über Standardstatus hinausgehen.
+**Wann nicht:** Bei simplen Statusanpassungen – dort bestehende State Machines nutzen.
+
+## Wo erweitern?
+- `acme_order_state.xml` – Definition aller Zustände/Übergänge.
+- `StateTransitionSubscriber.php` – Logik bei Transitionen.
+- `OVERVIEW.md` – Ergänzende Hinweise zu Command- oder Flow-Integration.
+
+## Weiterführend
+- Begriffe: StateMachineRegistry, TransitionEvent.
+- Suche nach `state-machine-order-state` im Core.
+- Themen: Flow Builder Trigger, ACL für State-Transitions.
+
+## Hinweise für Produktion
+- Statuswechsel testen (Happy/Edge Cases).
+- Dokumentation für Support-Teams bereitstellen.
+- Observability: Übergänge loggen und ggf. Metriken senden.

--- a/shopware-basics/state-machine/skeleton.tree
+++ b/shopware-basics/state-machine/skeleton.tree
@@ -1,0 +1,14 @@
+```
+state-machine/
+├── README.md
+├── OVERVIEW.md
+├── skeleton.tree
+└── src
+    ├── Resources
+    │   ├── config
+    │   │   └── services.xml
+    │   └── state-machine
+    │       └── acme_order_state.xml
+    └── Subscriber
+        └── StateTransitionSubscriber.php
+```

--- a/shopware-basics/state-machine/src/Resources/config/services.xml
+++ b/shopware-basics/state-machine/src/Resources/config/services.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Acme\\SwBasics\\StateMachine\\Subscriber\\StateTransitionSubscriber">
+            <argument type="service" id="logger"/>
+            <tag name="kernel.event_subscriber"/>
+        </service>
+    </services>
+</container>

--- a/shopware-basics/state-machine/src/Resources/state-machine/acme_order_state.xml
+++ b/shopware-basics/state-machine/src/Resources/state-machine/acme_order_state.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<state-machine xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/System/StateMachine/Schema/state-machine-1.0.xsd"
+               technical-name="acme_order_state"
+               initial-state="created">
+    <states>
+        <state technical-name="created" name="Erstellt"/>
+        <state technical-name="review" name="In Prüfung"/>
+        <state technical-name="completed" name="Abgeschlossen"/>
+        <state technical-name="cancelled" name="Storniert"/>
+    </states>
+
+    <transitions>
+        <transition action-name="prüfen"
+                    from="created"
+                    to="review"/>
+        <transition action-name="freigeben"
+                    from="review"
+                    to="completed"/>
+        <transition action-name="stornieren"
+                    from="created"
+                    to="cancelled"/>
+        <transition action-name="stornieren"
+                    from="review"
+                    to="cancelled"/>
+    </transitions>
+</state-machine>

--- a/shopware-basics/state-machine/src/Subscriber/StateTransitionSubscriber.php
+++ b/shopware-basics/state-machine/src/Subscriber/StateTransitionSubscriber.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acme\SwBasics\StateMachine\Subscriber;
+
+use Psr\Log\LoggerInterface;
+use Shopware\Core\System\StateMachine\Event\StateMachineTransitionEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Überwacht Transitionen der `acme_order_state` State Machine.
+ */
+class StateTransitionSubscriber implements EventSubscriberInterface
+{
+    public function __construct(private readonly LoggerInterface $logger)
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            StateMachineTransitionEvent::class => 'onTransition',
+        ];
+    }
+
+    public function onTransition(StateMachineTransitionEvent $event): void
+    {
+        if ($event->getStateMachineName() !== 'acme_order_state') {
+            return;
+        }
+
+        // TODO: Zusätzliche Prüfungen oder Aktionen ausführen (z. B. Benachrichtigung).
+        $this->logger->info('State Machine Transition verarbeitet.', [
+            'from' => $event->getFromPlace()->getTechnicalName(),
+            'to' => $event->getToPlace()->getTechnicalName(),
+            'action' => $event->getTransition()->getActionName(),
+        ]);
+    }
+}

--- a/shopware-basics/testing-ci/.php-cs-fixer.dist.php
+++ b/shopware-basics/testing-ci/.php-cs-fixer.dist.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
+$finder = Finder::create()
+    ->in(__DIR__ . '/src')
+    ->name('*.php');
+
+return (new Config())
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PSR12' => true,
+        'declare_strict_types' => true,
+    ])
+    ->setFinder($finder);

--- a/shopware-basics/testing-ci/OVERVIEW.md
+++ b/shopware-basics/testing-ci/OVERVIEW.md
@@ -1,0 +1,8 @@
+# Übersicht: Testing & CI Skeleton
+
+- `README.md` – Dokumentation.
+- `skeleton.tree` – Struktur.
+- `phpunit.xml.dist` – PHPUnit Konfiguration.
+- `phpstan.neon.dist` – PHPStan Einstellungen.
+- `.php-cs-fixer.dist.php` – Coding Style.
+- `tests/bootstrap.php` – Bootstrap-Datei für Tests.

--- a/shopware-basics/testing-ci/README.md
+++ b/shopware-basics/testing-ci/README.md
@@ -1,0 +1,38 @@
+# Testing & CI Skeleton
+
+## Was ist das?
+Dieses Skeleton liefert eine minimale Test- und QA-Konfiguration für Shopware-Projekte inklusive PHPUnit, PHPStan und PHP-CS-Fixer.
+
+## Typische Anwendungsfälle
+- Aufbau einer CI-Pipeline mit Standard-Tools.
+- Lokales Ausführen von Tests und Static Analysis.
+- Vorlage für Projekt-spezifische Konfigurationen.
+- Dokumentation von Quality-Gates.
+
+## Kurzes How-to
+1. `composer.json` im Hauptprojekt um PHPUnit, PHPStan und PHP-CS-Fixer ergänzen.
+2. `phpunit.xml.dist`, `phpstan.neon.dist` und `.php-cs-fixer.dist.php` anpassen.
+3. `tests/bootstrap.php` mit Autoload ergänzen.
+4. Tests in `tests/` ablegen und CI-Workflow konfigurieren.
+5. Kommandos lokal ausprobieren (`vendor/bin/phpunit`, `vendor/bin/phpstan analyse`).
+6. Ergebnisse in CI visualisieren (z. B. GitHub Actions, GitLab CI).
+
+## Wann einsetzen / Wann nicht
+**Wann einsetzen:** Wenn ein Projekt strukturierte Tests und Static Analysis benötigt.
+**Wann nicht:** Für Prototypen ohne QA-Anforderungen (kurzlebig).
+
+## Wo erweitern?
+- `phpunit.xml.dist` – Test-Suiten, Coverage.
+- `phpstan.neon.dist` – Level, IgnoreregEx.
+- `.php-cs-fixer.dist.php` – Coding-Style-Regeln.
+- `tests/bootstrap.php` – Setup/Mocks.
+
+## Weiterführend
+- Begriffe: TestSuite, Level 7/8, PSR-12.
+- Suche im Core nach bestehenden Tests (`tests/integration`).
+- Themen: Mutation Testing, Static Analysis Baseline.
+
+## Hinweise für Produktion
+- Tests automatisiert ausführen (CI).
+- Reports versionieren/archivieren.
+- Fail-Fast-Strategien (z. B. Lint vor Tests) definieren.

--- a/shopware-basics/testing-ci/phpstan.neon.dist
+++ b/shopware-basics/testing-ci/phpstan.neon.dist
@@ -1,0 +1,7 @@
+includes: []
+parameters:
+    level: 6
+    paths:
+        - src
+    tmpDir: var/cache/phpstan
+    checkMissingIterableValueType: true

--- a/shopware-basics/testing-ci/phpunit.xml.dist
+++ b/shopware-basics/testing-ci/phpunit.xml.dist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         cacheResult="false">
+    <testsuites>
+        <testsuite name="Project Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/shopware-basics/testing-ci/skeleton.tree
+++ b/shopware-basics/testing-ci/skeleton.tree
@@ -1,0 +1,11 @@
+```
+testing-ci/
+├── README.md
+├── OVERVIEW.md
+├── phpstan.neon.dist
+├── phpunit.xml.dist
+├── skeleton.tree
+├── tests
+│   └── bootstrap.php
+└── .php-cs-fixer.dist.php
+```

--- a/shopware-basics/testing-ci/tests/bootstrap.php
+++ b/shopware-basics/testing-ci/tests/bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+
+declare(strict_types=1);
+
+// Bootstrap für PHPUnit. Hier Autoload einbinden:
+// require dirname(__DIR__) . '/vendor/autoload.php';

--- a/shopware-basics/theme-storefront/OVERVIEW.md
+++ b/shopware-basics/theme-storefront/OVERVIEW.md
@@ -1,0 +1,9 @@
+# Übersicht: Theme Storefront Skeleton
+
+- `README.md` – Setup-Anleitung und Hinweise.
+- `composer.json` – Paketdefinition und Autoload.
+- `src/AcmeSwBasicsTheme.php` – Plugin-/Theme-Klasse.
+- `src/Resources/storefront/layout/header/logo.html.twig` – Twig-Override.
+- `src/Resources/app/storefront/src/plugin/acme-example.plugin.js` – JavaScript-Stub.
+- `src/Resources/app/storefront/src/scss/base.scss` – SCSS-Einstiegspunkt.
+- `skeleton.tree` – Strukturübersicht.

--- a/shopware-basics/theme-storefront/README.md
+++ b/shopware-basics/theme-storefront/README.md
@@ -1,0 +1,38 @@
+# Theme Storefront Skeleton
+
+## Was ist das?
+Dieses Skeleton liefert ein minimales Shopware-Theme inklusive Twig-Override, SCSS-Grundlage und JS-Plugin-Stub. Es dient als Startpunkt für visuelle Anpassungen ohne den Core zu verändern.
+
+## Typische Anwendungsfälle
+- Logos, Farben und Layouts projektspezifisch anpassen.
+- JavaScript-Hooks für Tracking oder Interaktionen einfügen.
+- SCSS-Variablen überschreiben und Komponenten erweitern.
+- Twig-Strukturen für Header/Footer individualisieren.
+
+## Kurzes How-to
+1. `composer.json` prüfen und Paketnamen anpassen (falls eigenes Repository).
+2. Plugin-Klasse `src/AcmeSwBasicsTheme.php` um Theme-Config erweitern.
+3. Twig, SCSS und JS nach Projektanforderungen füllen.
+4. Theme installieren (`bin/console plugin:install --activate AcmeSwBasicsTheme`).
+5. Cache leeren (`bin/console cache:clear`) und Theme kompilieren (`bin/console theme:compile`).
+6. Im Admin das Theme einem Verkaufskanal zuweisen und testen.
+
+## Wann einsetzen / Wann nicht
+**Wann einsetzen:** Für Layout/Styling-Anpassungen an der Storefront. Empfohlen bei Projekten mit klassischer Storefront.
+**Wann nicht:** Bei reinen Headless-Setups oder wenn nur einzelne CMS-Elemente angepasst werden müssen – dort schlankere Lösungen wählen.
+
+## Wo erweitern?
+- `src/AcmeSwBasicsTheme.php` – Einstiegspunkt, Theme-Konfiguration.
+- `src/Resources/storefront/layout/header/logo.html.twig` – Beispiel Override.
+- `src/Resources/app/storefront/src/plugin/acme-example.plugin.js` – JS-Injektionen.
+- `src/Resources/app/storefront/src/scss/base.scss` – SCSS-Basis.
+
+## Weiterführend
+- Suche nach `ThemeCompiler` im Core.
+- Twig Inheritance (`{% sw_extends %}`) verstehen.
+- SCSS Variablen: `@import 'component/_variables.scss'` im Core prüfen.
+
+## Hinweise für Produktion
+- Theme-Builds im CI erzeugen, um Deployments zu beschleunigen.
+- Assets versionieren (Cache-Busting) und CDN berücksichtigen.
+- Regressionstests für kritische Templates einplanen.

--- a/shopware-basics/theme-storefront/composer.json
+++ b/shopware-basics/theme-storefront/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "acme/swbasics-theme",
+    "type": "shopware-platform-plugin",
+    "description": "Skeleton Theme für Shopware Projekte",
+    "license": "proprietary",
+    "autoload": {
+        "psr-4": {
+            "Acme\\SwBasics\\ThemeStorefront\\": "src/"
+        }
+    }
+}

--- a/shopware-basics/theme-storefront/skeleton.tree
+++ b/shopware-basics/theme-storefront/skeleton.tree
@@ -1,0 +1,21 @@
+```
+theme-storefront/
+├── README.md
+├── OVERVIEW.md
+├── composer.json
+├── skeleton.tree
+└── src
+    ├── AcmeSwBasicsTheme.php
+    └── Resources
+        ├── app
+        │   └── storefront
+        │       └── src
+        │           ├── plugin
+        │           │   └── acme-example.plugin.js
+        │           └── scss
+        │               └── base.scss
+        └── storefront
+            └── layout
+                └── header
+                    └── logo.html.twig
+```

--- a/shopware-basics/theme-storefront/src/AcmeSwBasicsTheme.php
+++ b/shopware-basics/theme-storefront/src/AcmeSwBasicsTheme.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acme\SwBasics\ThemeStorefront;
+
+use Shopware\Core\Framework\Plugin;
+use Shopware\Storefront\Framework\ThemeInterface;
+
+/**
+ * Basis-Theme: Projekte ergänzen hier Theme-Konfiguration (z. B. ThemeConfigBuilder) und Assets.
+ */
+class AcmeSwBasicsTheme extends Plugin implements ThemeInterface
+{
+    // Optional: `getThemeConfigPath()` überschreiben, um eigene theme.json zu liefern.
+}

--- a/shopware-basics/theme-storefront/src/Resources/app/storefront/src/plugin/acme-example.plugin.js
+++ b/shopware-basics/theme-storefront/src/Resources/app/storefront/src/plugin/acme-example.plugin.js
@@ -1,0 +1,10 @@
+import Plugin from 'src/plugin-system/plugin.class';
+
+export default class AcmeExamplePlugin extends Plugin {
+    init() {
+        // Hier eigene JS-Logik ergänzen, z. B. DOM-Manipulationen oder Tracking.
+        this.el.dataset.acmeExample = 'initialized';
+    }
+}
+
+// Registrierung über main.js ergänzen, sobald weitere Plugins existieren.

--- a/shopware-basics/theme-storefront/src/Resources/app/storefront/src/scss/base.scss
+++ b/shopware-basics/theme-storefront/src/Resources/app/storefront/src/scss/base.scss
@@ -1,0 +1,6 @@
+// Basis-SCSS des Themes. Ergänzen Sie Variablen oder Komponenten.
+
+.acme-theme-logo-note {
+    font-size: 0.75rem;
+    color: $color-darkgray-200;
+}

--- a/shopware-basics/theme-storefront/src/Resources/storefront/layout/header/logo.html.twig
+++ b/shopware-basics/theme-storefront/src/Resources/storefront/layout/header/logo.html.twig
@@ -1,0 +1,6 @@
+{% sw_extends '@Storefront/storefront/layout/header/logo.html.twig' %}
+
+{% block layout_header_logo_image %}
+    {{ parent() }}
+    <span class="acme-theme-logo-note">[[Projektlogo Hinweis einfügen]]</span>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add shopware-basics/ workspace with 17 topic-specific skeletons covering custom fields, CMS, themes, apps, plugins, and more
- provide consistent READMEs, OVERVIEWs, skeleton.tree files, and minimal code placeholders aligned with Shopware extension points
- include configuration and stub implementations for events, DAL entities, state machines, payments, messaging, and testing/CI setups

## Testing
- not run