### PR TITLE
Add issues for acceptance criteria follow-ups

### DIFF
--- a/issues/01-akzeptanzkriterien-fuer-audit-logs-festlegen.md
+++ b/issues/01-akzeptanzkriterien-fuer-audit-logs-festlegen.md
@@ -1,0 +1,19 @@
+# Akzeptanzkriterien für Audit-Logs festlegen
+Datei: Randnotizen/Audit_Logging.md
+Zeile: 24
+Typ: PO
+Status: Bitte abstimmen
+---
+
+## Beschreibung
+Audit-Logs benötigen messbare Abnahmekriterien für Revisionssicherheit und Exportprüfungen.
+
+## Akzeptanzkriterien
+- Wenn Bedingung X, dann Ergebnis Y, gemessen durch Z.
+- Fehlerfälle definiert & dokumentiert.
+- Nachweis im Audit-Log oder Doku.
+
+## Labels
+- todo
+- compliance
+- product-owner

--- a/issues/02-akzeptanzkriterien-fuer-accessibility-definieren.md
+++ b/issues/02-akzeptanzkriterien-fuer-accessibility-definieren.md
@@ -1,0 +1,19 @@
+# Akzeptanzkriterien für Accessibility definieren
+Datei: Randnotizen/Accessibility_Barrierefreiheit.md
+Zeile: 35
+Typ: PO
+Status: Bitte abstimmen
+---
+
+## Beschreibung
+Für Barrierefreiheitsanforderungen fehlen messbare Akzeptanzkriterien für Nutzerprofile und Prüfnachweise.
+
+## Akzeptanzkriterien
+- Wenn Bedingung X, dann Ergebnis Y, gemessen durch Z.
+- Fehlerfälle definiert & dokumentiert.
+- Nachweis im Audit-Log oder Doku.
+
+## Labels
+- todo
+- accessibility
+- product-owner

--- a/issues/03-akzeptanzkriterien-fuer-freigabefaelle-ergaenzen.md
+++ b/issues/03-akzeptanzkriterien-fuer-freigabefaelle-ergaenzen.md
@@ -1,0 +1,19 @@
+# Akzeptanzkriterien für Freigabefälle ergänzen
+Datei: Randnotizen/Approval_Workflow.md
+Zeile: 31
+Typ: PO
+Status: Bitte abstimmen
+---
+
+## Beschreibung
+Der Approval-Workflow benötigt klare Kriterien wann Freigaben je Order-Level als erfüllt gelten.
+
+## Akzeptanzkriterien
+- Wenn Bedingung X, dann Ergebnis Y, gemessen durch Z.
+- Fehlerfälle definiert & dokumentiert.
+- Nachweis im Audit-Log oder Doku.
+
+## Labels
+- todo
+- workflow
+- product-owner

--- a/issues/04-akzeptanzkriterien-fuer-gesamtsicht-festlegen.md
+++ b/issues/04-akzeptanzkriterien-fuer-gesamtsicht-festlegen.md
@@ -1,0 +1,19 @@
+# Akzeptanzkriterien für Gesamtsicht festlegen
+Datei: Randnotizen/B2G_Besonderheiten.md
+Zeile: 28
+Typ: PO
+Status: Bitte abstimmen
+---
+
+## Beschreibung
+Für die Gesamtsicht der B2G-Besonderheiten fehlen definierte Minimalnachweise als Akzeptanzkriterien.
+
+## Akzeptanzkriterien
+- Wenn Bedingung X, dann Ergebnis Y, gemessen durch Z.
+- Fehlerfälle definiert & dokumentiert.
+- Nachweis im Audit-Log oder Doku.
+
+## Labels
+- todo
+- governance
+- product-owner

--- a/issues/05-akzeptanzkriterien-fuer-architektur-guidelines-formulieren.md
+++ b/issues/05-akzeptanzkriterien-fuer-architektur-guidelines-formulieren.md
@@ -1,0 +1,19 @@
+# Akzeptanzkriterien für Architektur-Guidelines formulieren
+Datei: Randnotizen/B2G_Technische_Auswirkungen.md
+Zeile: 24
+Typ: PO
+Status: Bitte abstimmen
+---
+
+## Beschreibung
+Architekturrichtlinien benötigen abgestimmte Akzeptanzkriterien zur technischen Bewertung.
+
+## Akzeptanzkriterien
+- Wenn Bedingung X, dann Ergebnis Y, gemessen durch Z.
+- Fehlerfälle definiert & dokumentiert.
+- Nachweis im Audit-Log oder Doku.
+
+## Labels
+- todo
+- architecture
+- product-owner

--- a/issues/06-akzeptanzkriterien-fuer-betriebsprozesse-beschreiben.md
+++ b/issues/06-akzeptanzkriterien-fuer-betriebsprozesse-beschreiben.md
@@ -1,0 +1,19 @@
+# Akzeptanzkriterien für Betriebsprozesse beschreiben
+Datei: Randnotizen/Betrieb_&_Governance.md
+Zeile: 26
+Typ: PO
+Status: Bitte abstimmen
+---
+
+## Beschreibung
+Für Betriebsprozesse fehlen messbare Kriterien zu Reaktionszeiten und Runbook-Übungen.
+
+## Akzeptanzkriterien
+- Wenn Bedingung X, dann Ergebnis Y, gemessen durch Z.
+- Fehlerfälle definiert & dokumentiert.
+- Nachweis im Audit-Log oder Doku.
+
+## Labels
+- todo
+- operations
+- product-owner

--- a/issues/07-akzeptanzkriterien-fuer-punchout-katalog-definieren.md
+++ b/issues/07-akzeptanzkriterien-fuer-punchout-katalog-definieren.md
@@ -1,0 +1,19 @@
+# Akzeptanzkriterien für Punchout/Katalog definieren
+Datei: Randnotizen/Broker_Integration_Punchout_&_Katalog.md
+Zeile: 26
+Typ: PO
+Status: Bitte abstimmen
+---
+
+## Beschreibung
+Punchout- und Katalogintegrationen benötigen Erfolgsnachweise wie OCI-Rückgabe und cXML-Validierung.
+
+## Akzeptanzkriterien
+- Wenn Bedingung X, dann Ergebnis Y, gemessen durch Z.
+- Fehlerfälle definiert & dokumentiert.
+- Nachweis im Audit-Log oder Doku.
+
+## Labels
+- todo
+- integration
+- product-owner

--- a/issues/08-akzeptanzkriterien-fuer-releases-definieren.md
+++ b/issues/08-akzeptanzkriterien-fuer-releases-definieren.md
@@ -1,0 +1,19 @@
+# Akzeptanzkriterien für Releases definieren
+Datei: Randnotizen/Change_&_Release.md
+Zeile: 26
+Typ: PO
+Status: Bitte abstimmen
+---
+
+## Beschreibung
+Für das Release-Management fehlen Kriterien wann ein Change als abgenommen gilt und welche KPIs relevant sind.
+
+## Akzeptanzkriterien
+- Wenn Bedingung X, dann Ergebnis Y, gemessen durch Z.
+- Fehlerfälle definiert & dokumentiert.
+- Nachweis im Audit-Log oder Doku.
+
+## Labels
+- todo
+- release-management
+- product-owner

--- a/issues/09-akzeptanzkriterien-fuer-formularuebermittlungen-ausarbeiten.md
+++ b/issues/09-akzeptanzkriterien-fuer-formularuebermittlungen-ausarbeiten.md
@@ -1,0 +1,19 @@
+# Akzeptanzkriterien für Formularübermittlungen ausarbeiten
+Datei: Randnotizen/CustomForms.md
+Zeile: 27
+Typ: PO
+Status: Bitte abstimmen
+---
+
+## Beschreibung
+Formularübermittlungen brauchen Kriterien zu Validierungsfehlerquoten und erfolgreicher Übergabe an Fachverfahren.
+
+## Akzeptanzkriterien
+- Wenn Bedingung X, dann Ergebnis Y, gemessen durch Z.
+- Fehlerfälle definiert & dokumentiert.
+- Nachweis im Audit-Log oder Doku.
+
+## Labels
+- todo
+- forms
+- product-owner

--- a/issues/10-akzeptanzkriterien-fuer-dokumentationsnachweise-definieren.md
+++ b/issues/10-akzeptanzkriterien-fuer-dokumentationsnachweise-definieren.md
@@ -1,0 +1,19 @@
+# Akzeptanzkriterien für Dokumentationsnachweise definieren
+Datei: Randnotizen/Dokumentation_&_Archivierung.md
+Zeile: 27
+Typ: PO
+Status: Bitte abstimmen
+---
+
+## Beschreibung
+Für Dokumentations- und Archivierungsnachweise fehlen Kriterien zu Vollständigkeit und Aufbewahrung.
+
+## Akzeptanzkriterien
+- Wenn Bedingung X, dann Ergebnis Y, gemessen durch Z.
+- Fehlerfälle definiert & dokumentiert.
+- Nachweis im Audit-Log oder Doku.
+
+## Labels
+- todo
+- documentation
+- product-owner

--- a/issues/11-akzeptanzkriterien-fuer-rpo-rto-nachweise-festlegen.md
+++ b/issues/11-akzeptanzkriterien-fuer-rpo-rto-nachweise-festlegen.md
@@ -1,0 +1,19 @@
+# Akzeptanzkriterien für RPO/RTO-Nachweise festlegen
+Datei: Randnotizen/DrBackup_&_Wiederherstellung.md
+Zeile: 25
+Typ: PO
+Status: Bitte abstimmen
+---
+
+## Beschreibung
+Disaster-Recovery verlangt definierte Kriterien für RPO/RTO-Nachweise und Restore-Tests.
+
+## Akzeptanzkriterien
+- Wenn Bedingung X, dann Ergebnis Y, gemessen durch Z.
+- Fehlerfälle definiert & dokumentiert.
+- Nachweis im Audit-Log oder Doku.
+
+## Labels
+- todo
+- disaster-recovery
+- product-owner

--- a/issues/12-akzeptanzkriterien-fuer-erp-integration-definieren.md
+++ b/issues/12-akzeptanzkriterien-fuer-erp-integration-definieren.md
@@ -1,0 +1,19 @@
+# Akzeptanzkriterien für ERP-Integration definieren
+Datei: Randnotizen/ERP_Schnittstellen.md
+Zeile: 24
+Typ: PO
+Status: Bitte abstimmen
+---
+
+## Beschreibung
+ERP-Schnittstellen benötigen definierte Erfolgsquoten und Latenzgrenzen als Akzeptanzkriterien.
+
+## Akzeptanzkriterien
+- Wenn Bedingung X, dann Ergebnis Y, gemessen durch Z.
+- Fehlerfälle definiert & dokumentiert.
+- Nachweis im Audit-Log oder Doku.
+
+## Labels
+- todo
+- integration
+- product-owner

--- a/issues/13-akzeptanzkriterien-fuer-faq-abdeckung-definieren.md
+++ b/issues/13-akzeptanzkriterien-fuer-faq-abdeckung-definieren.md
@@ -1,0 +1,19 @@
+# Akzeptanzkriterien für FAQ-Abdeckung definieren
+Datei: Randnotizen/FAQ.md
+Zeile: 30
+Typ: PO
+Status: Bitte abstimmen
+---
+
+## Beschreibung
+Für die FAQ fehlen Checklisten-Kriterien welche Themen vollständig beantwortet sein müssen.
+
+## Akzeptanzkriterien
+- Wenn Bedingung X, dann Ergebnis Y, gemessen durch Z.
+- Fehlerfälle definiert & dokumentiert.
+- Nachweis im Audit-Log oder Doku.
+
+## Labels
+- todo
+- knowledge-base
+- product-owner

--- a/issues/14-akzeptanzkriterien-fuer-xrechnung-ergaenzen.md
+++ b/issues/14-akzeptanzkriterien-fuer-xrechnung-ergaenzen.md
@@ -1,0 +1,19 @@
+# Akzeptanzkriterien für XRechnung ergänzen
+Datei: Randnotizen/Invoicing_XRechnung_ZUGFeRD.md
+Zeile: 30
+Typ: PO
+Status: Bitte abstimmen
+---
+
+## Beschreibung
+XRechnungsprozesse benötigen Validierungs-, PEPPOL- und Archivnachweise als Akzeptanzkriterien.
+
+## Akzeptanzkriterien
+- Wenn Bedingung X, dann Ergebnis Y, gemessen durch Z.
+- Fehlerfälle definiert & dokumentiert.
+- Nachweis im Audit-Log oder Doku.
+
+## Labels
+- todo
+- invoicing
+- product-owner

--- a/issues/15-akzeptanzkriterien-fuer-budgetpruefungen-festlegen.md
+++ b/issues/15-akzeptanzkriterien-fuer-budgetpruefungen-festlegen.md
@@ -1,0 +1,19 @@
+# Akzeptanzkriterien für Budgetprüfungen festlegen
+Datei: Randnotizen/Kostenstellen_&_Budgets.md
+Zeile: 24
+Typ: PO
+Status: Bitte abstimmen
+---
+
+## Beschreibung
+Budgetprüfungen brauchen definierte Fehlerfälle, Schwellenwerte und Reporting-Kriterien.
+
+## Akzeptanzkriterien
+- Wenn Bedingung X, dann Ergebnis Y, gemessen durch Z.
+- Fehlerfälle definiert & dokumentiert.
+- Nachweis im Audit-Log oder Doku.
+
+## Labels
+- todo
+- finance
+- product-owner

--- a/issues/16-akzeptanzkriterien-fuer-mandatsnutzung-definieren.md
+++ b/issues/16-akzeptanzkriterien-fuer-mandatsnutzung-definieren.md
@@ -1,0 +1,19 @@
+# Akzeptanzkriterien für Mandatsnutzung definieren
+Datei: Randnotizen/Mandate_Management.md
+Zeile: 26
+Typ: PO
+Status: Bitte abstimmen
+---
+
+## Beschreibung
+Mandatsverwaltung benötigt Kriterien zu Audit-Logs und Ablaufbehandlungen von Mandaten.
+
+## Akzeptanzkriterien
+- Wenn Bedingung X, dann Ergebnis Y, gemessen durch Z.
+- Fehlerfälle definiert & dokumentiert.
+- Nachweis im Audit-Log oder Doku.
+
+## Labels
+- todo
+- authorization
+- product-owner

--- a/issues/17-akzeptanzkriterien-fuer-monitoring-definieren.md
+++ b/issues/17-akzeptanzkriterien-fuer-monitoring-definieren.md
@@ -1,0 +1,19 @@
+# Akzeptanzkriterien für Monitoring definieren
+Datei: Randnotizen/Monitoring_&_Alerting.md
+Zeile: 28
+Typ: PO
+Status: Bitte abstimmen
+---
+
+## Beschreibung
+Monitoring und Alerting brauchen messbare SLA-Nachweise und Reaktionszeiten als Kriterien.
+
+## Akzeptanzkriterien
+- Wenn Bedingung X, dann Ergebnis Y, gemessen durch Z.
+- Fehlerfälle definiert & dokumentiert.
+- Nachweis im Audit-Log oder Doku.
+
+## Labels
+- todo
+- monitoring
+- product-owner

--- a/issues/18-akzeptanzkriterien-fuer-rollenvergabe-definieren.md
+++ b/issues/18-akzeptanzkriterien-fuer-rollenvergabe-definieren.md
@@ -1,0 +1,19 @@
+# Akzeptanzkriterien für Rollenvergabe definieren
+Datei: Randnotizen/Rollen_&_Rechte.md
+Zeile: 32
+Typ: PO
+Status: Bitte abstimmen
+---
+
+## Beschreibung
+Für Rollen- und Rechteverwaltung fehlen Prüfintervalle und Audit-Belege als Akzeptanzkriterien.
+
+## Akzeptanzkriterien
+- Wenn Bedingung X, dann Ergebnis Y, gemessen durch Z.
+- Fehlerfälle definiert & dokumentiert.
+- Nachweis im Audit-Log oder Doku.
+
+## Labels
+- todo
+- security
+- product-owner

--- a/issues/19-akzeptanzkriterien-fuer-sso-festlegen.md
+++ b/issues/19-akzeptanzkriterien-fuer-sso-festlegen.md
@@ -1,0 +1,19 @@
+# Akzeptanzkriterien für SSO festlegen
+Datei: Randnotizen/Single_Sign-On_&_IdM.md
+Zeile: 24
+Typ: PO
+Status: Bitte abstimmen
+---
+
+## Beschreibung
+SSO/IdM erfordert Kriterien zu IdP-Failover, Token-Validierung und Deprovisioning-Laufzeiten.
+
+## Akzeptanzkriterien
+- Wenn Bedingung X, dann Ergebnis Y, gemessen durch Z.
+- Fehlerfälle definiert & dokumentiert.
+- Nachweis im Audit-Log oder Doku.
+
+## Labels
+- todo
+- identity
+- product-owner

--- a/issues/20-akzeptanzkriterien-fuer-abnahmen-definieren.md
+++ b/issues/20-akzeptanzkriterien-fuer-abnahmen-definieren.md
@@ -1,0 +1,19 @@
+# Akzeptanzkriterien für Abnahmen definieren
+Datei: Randnotizen/Testing_&_Abnahme.md
+Zeile: 27
+Typ: PO
+Status: Bitte abstimmen
+---
+
+## Beschreibung
+Test- und Abnahmeprozesse benötigen definierte Mindestumfänge und Nachweisformate als Kriterien.
+
+## Akzeptanzkriterien
+- Wenn Bedingung X, dann Ergebnis Y, gemessen durch Z.
+- Fehlerfälle definiert & dokumentiert.
+- Nachweis im Audit-Log oder Doku.
+
+## Labels
+- todo
+- testing
+- product-owner

--- a/issues/21-akzeptanzkriterien-fuer-mandanten-themes-ausarbeiten.md
+++ b/issues/21-akzeptanzkriterien-fuer-mandanten-themes-ausarbeiten.md
@@ -1,0 +1,19 @@
+# Akzeptanzkriterien für Mandanten-Themes ausarbeiten
+Datei: Randnotizen/Theming_&_Branding_Mandanten.md
+Zeile: 30
+Typ: PO
+Status: Bitte abstimmen
+---
+
+## Beschreibung
+Mandanten-Themes brauchen Kriterien zu Kontrast, Browserkompatibilität und Mandantenwechsel.
+
+## Akzeptanzkriterien
+- Wenn Bedingung X, dann Ergebnis Y, gemessen durch Z.
+- Fehlerfälle definiert & dokumentiert.
+- Nachweis im Audit-Log oder Doku.
+
+## Labels
+- todo
+- ux
+- product-owner


### PR DESCRIPTION
## Summary
- add GitHub issue markdown files covering each Randnotizen TODO that calls out missing acceptance criteria
- populate every issue with description, default acceptance criteria checklist, and labels for tracking

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9bd324cd08329babd6884bf887d47