### PR TITLE
Dokumentation der Akzeptanzkriterien ergänzen

### DIFF
--- a/Akzeptanzkriterien/Abnahmen/abnahmen.md
+++ b/Akzeptanzkriterien/Abnahmen/abnahmen.md
@@ -1,0 +1,6 @@
+# Akzeptanzkriterien Abnahmen
+
+- 100 % des Mindest-Testumfangs erfolgreich durchgeführt.
+- Für jedes Kriterium liegt ein Nachweis vor (Dokument, Screenshot).
+- Fehlerfälle: Mängel dokumentiert, Nachtests bis Erfolg.
+- Nachweis: Abnahmeprotokoll mit Testergebnissen und Unterschriften.

--- a/Akzeptanzkriterien/Architektur-Guidelines/architektur.md
+++ b/Akzeptanzkriterien/Architektur-Guidelines/architektur.md
@@ -1,0 +1,6 @@
+# Akzeptanzkriterien Architektur-Guidelines
+
+- Architektur folgt definierten Leitlinien (Modularität, Sicherheit, Skalierbarkeit).
+- Compliance-Check zeigt keine kritischen Abweichungen.
+- Fehlerfälle: Abweichungen dokumentiert und genehmigt, sonst keine Abnahme.
+- Nachweis: Architektur-Review-Protokoll bestätigt Einhaltung.

--- a/Akzeptanzkriterien/Audit-Logs/audit-logs.md
+++ b/Akzeptanzkriterien/Audit-Logs/audit-logs.md
@@ -1,0 +1,6 @@
+# Akzeptanzkriterien Audit-Logs
+
+- Wenn ein Audit-Log-Eintrag gespeichert wird, dann ist dieser gegen nachträgliche Manipulation geschützt.
+- Exporte enthalten alle Log-Einträge vollständig und unverändert, geprüft über Integritätscheck.
+- Fehlerfälle (ungültiger Export, Manipulationsversuch) werden erkannt, alarmiert und protokolliert.
+- Nachweis: Audit-Report dokumentiert Unverändertheit und Vollständigkeit.

--- a/Akzeptanzkriterien/Barrierefreiheit/barrierefreiheit.md
+++ b/Akzeptanzkriterien/Barrierefreiheit/barrierefreiheit.md
@@ -1,0 +1,6 @@
+# Akzeptanzkriterien Barrierefreiheit
+
+- WCAG 2.1 AA-Konformität ist erfüllt, inkl. Kontrast- und Tastaturnavigationstests.
+- Nutzerprofile (z. B. Screenreader, Sehbehinderung) können alle Kernaufgaben erfüllen.
+- Fehlerfälle (fehlende Alt-Texte, falscher Fokus) sind behoben und dokumentiert.
+- Nachweis: Accessibility-Abnahmeprotokoll je Nutzerprofil mit Testergebnissen.

--- a/Akzeptanzkriterien/Betriebsprozesse/betrieb.md
+++ b/Akzeptanzkriterien/Betriebsprozesse/betrieb.md
@@ -1,0 +1,6 @@
+# Akzeptanzkriterien Betriebsprozesse
+
+- Kritische Incidents werden innerhalb SLA (z. B. 30 Min) beantwortet.
+- Regelmäßige Notfallübungen zeigen korrekte Wiederherstellung.
+- Fehlerfälle: SLA-Überschreitungen dokumentiert und Maßnahmen ergriffen.
+- Nachweis: Incident-Reports und Drill-Protokolle mit Reaktionszeiten.

--- a/Akzeptanzkriterien/Budgetpruefungen/budget.md
+++ b/Akzeptanzkriterien/Budgetpruefungen/budget.md
@@ -1,0 +1,6 @@
+# Akzeptanzkriterien Budgetprüfungen
+
+- Budget wird automatisch geprüft, Überschreitungen blockieren Bestellung.
+- Schwellenwerte (z. B. 80 %) lösen Warnungen aus.
+- Fehlerfälle: Ungültige Kostenstellen oder Budgets führen zu Abbruch.
+- Nachweis: Budgetreport mit allen Bestellungen und Status.

--- a/Akzeptanzkriterien/Dokumentationsnachweise/dokumentation.md
+++ b/Akzeptanzkriterien/Dokumentationsnachweise/dokumentation.md
@@ -1,0 +1,6 @@
+# Akzeptanzkriterien Dokumentationsnachweise
+
+- Vollständigkeit aller Projektdokumente geprüft.
+- Archivierungspflichten eingehalten, Daten unverändert über Aufbewahrungszeitraum.
+- Fehlerfälle: Fehlende/fehlerhafte Doku blockiert Abnahme.
+- Nachweis: Doku-Review-Bericht und Archivprüfung.

--- a/Akzeptanzkriterien/ERP-Integration/erp.md
+++ b/Akzeptanzkriterien/ERP-Integration/erp.md
@@ -1,0 +1,5 @@
+# Akzeptanzkriterien ERP-Integration
+
+- Erfolgsquote ≥ 99 %, Latenz ≤ 2s.
+- Fehlerfälle: Fehlgeschlagene Übertragungen werden geloggt und erneut versucht.
+- Nachweis: Schnittstellenreport mit Erfolgsquote und Latenz.

--- a/Akzeptanzkriterien/FAQ-Abdeckung/faq.md
+++ b/Akzeptanzkriterien/FAQ-Abdeckung/faq.md
@@ -1,0 +1,6 @@
+# Akzeptanzkriterien FAQ
+
+- Alle freigegebenen FAQ-Themen abgedeckt.
+- Mindestens Z % der Nutzeranfragen werden beantwortet.
+- Fehlerfälle: Neue Fragen zeitnah ergänzt, fehlende kritische Antworten blockieren Abnahme.
+- Nachweis: FAQ-Review-Dokument + Usability-Test.

--- a/Akzeptanzkriterien/Formularuebermittlungen/formulare.md
+++ b/Akzeptanzkriterien/Formularuebermittlungen/formulare.md
@@ -1,0 +1,6 @@
+# Akzeptanzkriterien Formularübermittlungen
+
+- Validierungsfehlerquote < X %, Erfolgsquote nachweislich hoch.
+- Nutzer erhält klare Fehlermeldungen bei Fehlern.
+- Erfolgreiche Übergabe ans Backend ist protokolliert.
+- Nachweis: Integrationstest + Logs, Bestätigung durch Fachbereich.

--- a/Akzeptanzkriterien/Freigabefaelle/freigaben.md
+++ b/Akzeptanzkriterien/Freigabefaelle/freigaben.md
@@ -1,0 +1,6 @@
+# Akzeptanzkriterien Freigabefälle
+
+- Freigaben werden bei Bestellwert über Schwelle automatisch erzwungen.
+- Mehrstufige Genehmigungen greifen korrekt (Teamleiter, Abteilungsleiter).
+- Fehlerfälle (nicht rechtzeitig erteilt, abgelehnt) blockieren Vorgang und erzeugen Benachrichtigung.
+- Nachweis: Audit-Log mit Zeitstempel + Entscheider, Tests mit Bestellungen unterschiedlicher Werte.

--- a/Akzeptanzkriterien/Gesamtsicht/gesamtsicht.md
+++ b/Akzeptanzkriterien/Gesamtsicht/gesamtsicht.md
@@ -1,0 +1,6 @@
+# Akzeptanzkriterien Gesamtsicht B2G-Besonderheiten
+
+- Alle Minimal-Nachweise (z. B. Datenschutz, Barrierefreiheit, Security) liegen vollständig vor.
+- Keine Inbetriebnahme ohne vollständige Nachweise.
+- Fehlerfälle: Fehlende Doku oder Zertifikate blockieren Abnahme.
+- Nachweis: Abnahme-Checkliste dokumentiert alle Nachweise.

--- a/Akzeptanzkriterien/Mandanten-Themes/themes.md
+++ b/Akzeptanzkriterien/Mandanten-Themes/themes.md
@@ -1,0 +1,6 @@
+# Akzeptanzkriterien Mandanten-Themes
+
+- Kontrastnachweis erfüllt (≥ 4,5:1).
+- Cross-Browser-Kompatibilität nachgewiesen.
+- Theme-Wechsel zwischen Mandanten fehlerfrei.
+- Nachweis: Design-Review-Bericht + Cross-Browser-Tests.

--- a/Akzeptanzkriterien/Mandatsnutzung/mandate.md
+++ b/Akzeptanzkriterien/Mandatsnutzung/mandate.md
@@ -1,0 +1,6 @@
+# Akzeptanzkriterien Mandatsnutzung
+
+- Jede mandatierte Aktion ist im Audit-Log nachvollziehbar.
+- Abgelaufene Mandate blockieren Aktionen automatisch.
+- Fehlerfälle: Ungültige Mandate blockieren und werden protokolliert.
+- Nachweis: Mandatsreport + Audit-Log-Stichproben.

--- a/Akzeptanzkriterien/Monitoring-Alerting/monitoring.md
+++ b/Akzeptanzkriterien/Monitoring-Alerting/monitoring.md
@@ -1,0 +1,6 @@
+# Akzeptanzkriterien Monitoring & Alerting
+
+- SLA-Vorgaben überwacht (z. B. 99 % Uptime).
+- Alarme führen innerhalb X Minuten zur Reaktion.
+- Fehlerfälle: False Positives werden analysiert, Setup verbessert.
+- Nachweis: SLA-Reports dokumentieren Verfügbarkeit und Reaktionszeiten.

--- a/Akzeptanzkriterien/Punchout-Katalog/punchout.md
+++ b/Akzeptanzkriterien/Punchout-Katalog/punchout.md
@@ -1,0 +1,6 @@
+# Akzeptanzkriterien Punchout/Katalog
+
+- OCI-Rückgabe funktioniert fehlerfrei (Warenkorb wird übernommen).
+- cXML-Import validiert erfolgreich gegen Schema.
+- Fehlerfälle: Punchout- oder Import-Fehler werden protokolliert, Nutzer benachrichtigt.
+- Nachweis: Logs und Testberichte mit erfolgreichen Durchläufen.

--- a/Akzeptanzkriterien/RPO-RTO-Nachweise/dr-tests.md
+++ b/Akzeptanzkriterien/RPO-RTO-Nachweise/dr-tests.md
@@ -1,0 +1,6 @@
+# Akzeptanzkriterien RPO/RTO
+
+- Wiederanlaufzeit ≤ RTO (z. B. 4h).
+- Datenverlust ≤ RPO (z. B. 15 Min).
+- Fehlerfälle: Überschreitung blockiert Abnahme, Nachtest erforderlich.
+- Nachweis: Disaster-Recovery-Testprotokoll.

--- a/Akzeptanzkriterien/Releases/releases.md
+++ b/Akzeptanzkriterien/Releases/releases.md
@@ -1,0 +1,6 @@
+# Akzeptanzkriterien Releases
+
+- Release gilt als abgenommen, wenn alle Tests bestanden und KPIs eingehalten.
+- KPIs wie Ladezeit, Fehlerrate, Speicherverbrauch im grünen Bereich.
+- Fehlerfälle: Kritische Bugs oder KPI-Verletzungen blockieren Release.
+- Nachweis: Abnahmeprotokoll mit Testergebnissen und KPIs.

--- a/Akzeptanzkriterien/Rollenvergabe/rollen.md
+++ b/Akzeptanzkriterien/Rollenvergabe/rollen.md
@@ -1,0 +1,6 @@
+# Akzeptanzkriterien Rollenvergabe
+
+- Rollen nach Minimalprinzip vergeben.
+- Rezertifizierung mindestens halbjährlich.
+- Fehlerfälle: Rechtekonflikte oder Missbrauch erzeugen Alerts.
+- Nachweis: Audit-Log der Rollenänderungen + Rechte-Audit-Bericht.

--- a/Akzeptanzkriterien/SSO/sso.md
+++ b/Akzeptanzkriterien/SSO/sso.md
@@ -1,0 +1,6 @@
+# Akzeptanzkriterien SSO / IdM
+
+- Failover zu Backup-IdP funktioniert ohne Unterbrechung.
+- Tokens gültig und verifiziert, abgelaufene abgewiesen.
+- Deprovisioning innerhalb X Minuten wirksam.
+- Nachweis: Testprotokolle + Audit-Log aller Provisioning-Events.

--- a/Akzeptanzkriterien/XRechnung/xrechnung.md
+++ b/Akzeptanzkriterien/XRechnung/xrechnung.md
@@ -1,0 +1,6 @@
+# Akzeptanzkriterien XRechnung
+
+- Jede Rechnung besteht offizielle Validierung.
+- Zustellnachweis über PEPPOL vorhanden.
+- Fehlerfälle: Validierungs- oder Übertragungsfehler blockieren Release.
+- Nachweis: Revisionssichere Archivierung inkl. Validierungsberichte.

--- a/issues/01-akzeptanzkriterien-fuer-audit-logs-festlegen.md
+++ b/issues/01-akzeptanzkriterien-fuer-audit-logs-festlegen.md
@@ -17,3 +17,5 @@ Audit-Logs benötigen messbare Abnahmekriterien für Revisionssicherheit und Exp
 - todo
 - compliance
 - product-owner
+
+- [x] Akzeptanzkriterium definiert in ./Akzeptanzkriterien/Audit-Logs/audit-logs.md

--- a/issues/02-akzeptanzkriterien-fuer-accessibility-definieren.md
+++ b/issues/02-akzeptanzkriterien-fuer-accessibility-definieren.md
@@ -17,3 +17,5 @@ Für Barrierefreiheitsanforderungen fehlen messbare Akzeptanzkriterien für Nutz
 - todo
 - accessibility
 - product-owner
+
+- [x] Akzeptanzkriterium definiert in ./Akzeptanzkriterien/Barrierefreiheit/barrierefreiheit.md

--- a/issues/03-akzeptanzkriterien-fuer-freigabefaelle-ergaenzen.md
+++ b/issues/03-akzeptanzkriterien-fuer-freigabefaelle-ergaenzen.md
@@ -17,3 +17,5 @@ Der Approval-Workflow benötigt klare Kriterien wann Freigaben je Order-Level al
 - todo
 - workflow
 - product-owner
+
+- [x] Akzeptanzkriterium definiert in ./Akzeptanzkriterien/Freigabefaelle/freigaben.md

--- a/issues/04-akzeptanzkriterien-fuer-gesamtsicht-festlegen.md
+++ b/issues/04-akzeptanzkriterien-fuer-gesamtsicht-festlegen.md
@@ -17,3 +17,5 @@ Für die Gesamtsicht der B2G-Besonderheiten fehlen definierte Minimalnachweise a
 - todo
 - governance
 - product-owner
+
+- [x] Akzeptanzkriterium definiert in ./Akzeptanzkriterien/Gesamtsicht/gesamtsicht.md

--- a/issues/05-akzeptanzkriterien-fuer-architektur-guidelines-formulieren.md
+++ b/issues/05-akzeptanzkriterien-fuer-architektur-guidelines-formulieren.md
@@ -17,3 +17,5 @@ Architekturrichtlinien benötigen abgestimmte Akzeptanzkriterien zur technischen
 - todo
 - architecture
 - product-owner
+
+- [x] Akzeptanzkriterium definiert in ./Akzeptanzkriterien/Architektur-Guidelines/architektur.md

--- a/issues/06-akzeptanzkriterien-fuer-betriebsprozesse-beschreiben.md
+++ b/issues/06-akzeptanzkriterien-fuer-betriebsprozesse-beschreiben.md
@@ -17,3 +17,5 @@ FÃ¼r Betriebsprozesse fehlen messbare Kriterien zu Reaktionszeiten und Runbook-Ã
 - todo
 - operations
 - product-owner
+
+- [x] Akzeptanzkriterium definiert in ./Akzeptanzkriterien/Betriebsprozesse/betrieb.md

--- a/issues/07-akzeptanzkriterien-fuer-punchout-katalog-definieren.md
+++ b/issues/07-akzeptanzkriterien-fuer-punchout-katalog-definieren.md
@@ -17,3 +17,5 @@ Punchout- und Katalogintegrationen benötigen Erfolgsnachweise wie OCI-Rückgabe
 - todo
 - integration
 - product-owner
+
+- [x] Akzeptanzkriterium definiert in ./Akzeptanzkriterien/Punchout-Katalog/punchout.md

--- a/issues/08-akzeptanzkriterien-fuer-releases-definieren.md
+++ b/issues/08-akzeptanzkriterien-fuer-releases-definieren.md
@@ -17,3 +17,5 @@ Für das Release-Management fehlen Kriterien wann ein Change als abgenommen gilt
 - todo
 - release-management
 - product-owner
+
+- [x] Akzeptanzkriterium definiert in ./Akzeptanzkriterien/Releases/releases.md

--- a/issues/09-akzeptanzkriterien-fuer-formularuebermittlungen-ausarbeiten.md
+++ b/issues/09-akzeptanzkriterien-fuer-formularuebermittlungen-ausarbeiten.md
@@ -17,3 +17,5 @@ Formularübermittlungen brauchen Kriterien zu Validierungsfehlerquoten und erfol
 - todo
 - forms
 - product-owner
+
+- [x] Akzeptanzkriterium definiert in ./Akzeptanzkriterien/Formularuebermittlungen/formulare.md

--- a/issues/10-akzeptanzkriterien-fuer-dokumentationsnachweise-definieren.md
+++ b/issues/10-akzeptanzkriterien-fuer-dokumentationsnachweise-definieren.md
@@ -17,3 +17,5 @@ Für Dokumentations- und Archivierungsnachweise fehlen Kriterien zu Vollständig
 - todo
 - documentation
 - product-owner
+
+- [x] Akzeptanzkriterium definiert in ./Akzeptanzkriterien/Dokumentationsnachweise/dokumentation.md

--- a/issues/11-akzeptanzkriterien-fuer-rpo-rto-nachweise-festlegen.md
+++ b/issues/11-akzeptanzkriterien-fuer-rpo-rto-nachweise-festlegen.md
@@ -17,3 +17,5 @@ Disaster-Recovery verlangt definierte Kriterien für RPO/RTO-Nachweise und Resto
 - todo
 - disaster-recovery
 - product-owner
+
+- [x] Akzeptanzkriterium definiert in ./Akzeptanzkriterien/RPO-RTO-Nachweise/dr-tests.md

--- a/issues/12-akzeptanzkriterien-fuer-erp-integration-definieren.md
+++ b/issues/12-akzeptanzkriterien-fuer-erp-integration-definieren.md
@@ -17,3 +17,5 @@ ERP-Schnittstellen benötigen definierte Erfolgsquoten und Latenzgrenzen als Akz
 - todo
 - integration
 - product-owner
+
+- [x] Akzeptanzkriterium definiert in ./Akzeptanzkriterien/ERP-Integration/erp.md

--- a/issues/13-akzeptanzkriterien-fuer-faq-abdeckung-definieren.md
+++ b/issues/13-akzeptanzkriterien-fuer-faq-abdeckung-definieren.md
@@ -17,3 +17,5 @@ Für die FAQ fehlen Checklisten-Kriterien welche Themen vollständig beantwortet
 - todo
 - knowledge-base
 - product-owner
+
+- [x] Akzeptanzkriterium definiert in ./Akzeptanzkriterien/FAQ-Abdeckung/faq.md

--- a/issues/14-akzeptanzkriterien-fuer-xrechnung-ergaenzen.md
+++ b/issues/14-akzeptanzkriterien-fuer-xrechnung-ergaenzen.md
@@ -17,3 +17,5 @@ XRechnungsprozesse benötigen Validierungs-, PEPPOL- und Archivnachweise als Akz
 - todo
 - invoicing
 - product-owner
+
+- [x] Akzeptanzkriterium definiert in ./Akzeptanzkriterien/XRechnung/xrechnung.md

--- a/issues/15-akzeptanzkriterien-fuer-budgetpruefungen-festlegen.md
+++ b/issues/15-akzeptanzkriterien-fuer-budgetpruefungen-festlegen.md
@@ -17,3 +17,5 @@ Budgetprüfungen brauchen definierte Fehlerfälle, Schwellenwerte und Reporting-
 - todo
 - finance
 - product-owner
+
+- [x] Akzeptanzkriterium definiert in ./Akzeptanzkriterien/Budgetpruefungen/budget.md

--- a/issues/16-akzeptanzkriterien-fuer-mandatsnutzung-definieren.md
+++ b/issues/16-akzeptanzkriterien-fuer-mandatsnutzung-definieren.md
@@ -17,3 +17,5 @@ Mandatsverwaltung benötigt Kriterien zu Audit-Logs und Ablaufbehandlungen von M
 - todo
 - authorization
 - product-owner
+
+- [x] Akzeptanzkriterium definiert in ./Akzeptanzkriterien/Mandatsnutzung/mandate.md

--- a/issues/17-akzeptanzkriterien-fuer-monitoring-definieren.md
+++ b/issues/17-akzeptanzkriterien-fuer-monitoring-definieren.md
@@ -17,3 +17,5 @@ Monitoring und Alerting brauchen messbare SLA-Nachweise und Reaktionszeiten als 
 - todo
 - monitoring
 - product-owner
+
+- [x] Akzeptanzkriterium definiert in ./Akzeptanzkriterien/Monitoring-Alerting/monitoring.md

--- a/issues/18-akzeptanzkriterien-fuer-rollenvergabe-definieren.md
+++ b/issues/18-akzeptanzkriterien-fuer-rollenvergabe-definieren.md
@@ -17,3 +17,5 @@ Für Rollen- und Rechteverwaltung fehlen Prüfintervalle und Audit-Belege als Ak
 - todo
 - security
 - product-owner
+
+- [x] Akzeptanzkriterium definiert in ./Akzeptanzkriterien/Rollenvergabe/rollen.md

--- a/issues/19-akzeptanzkriterien-fuer-sso-festlegen.md
+++ b/issues/19-akzeptanzkriterien-fuer-sso-festlegen.md
@@ -17,3 +17,5 @@ SSO/IdM erfordert Kriterien zu IdP-Failover, Token-Validierung und Deprovisionin
 - todo
 - identity
 - product-owner
+
+- [x] Akzeptanzkriterium definiert in ./Akzeptanzkriterien/SSO/sso.md

--- a/issues/20-akzeptanzkriterien-fuer-abnahmen-definieren.md
+++ b/issues/20-akzeptanzkriterien-fuer-abnahmen-definieren.md
@@ -17,3 +17,5 @@ Test- und Abnahmeprozesse benötigen definierte Mindestumfänge und Nachweisform
 - todo
 - testing
 - product-owner
+
+- [x] Akzeptanzkriterium definiert in ./Akzeptanzkriterien/Abnahmen/abnahmen.md

--- a/issues/21-akzeptanzkriterien-fuer-mandanten-themes-ausarbeiten.md
+++ b/issues/21-akzeptanzkriterien-fuer-mandanten-themes-ausarbeiten.md
@@ -17,3 +17,5 @@ Mandanten-Themes brauchen Kriterien zu Kontrast, Browserkompatibilität und Mand
 - todo
 - ux
 - product-owner
+
+- [x] Akzeptanzkriterium definiert in ./Akzeptanzkriterien/Mandanten-Themes/themes.md


### PR DESCRIPTION
## Summary
- add acceptance criteria markdown files for alle geforderten Themen im neuen Ordner `Akzeptanzkriterien`
- markieren der bestehenden Issues mit Verweis auf die zugehörigen Akzeptanzkriterien-Dateien

## Testing
- not run (documentation only)