### PR TITLE
Fix approval request persistence issues

### DIFF
--- a/src/B2gApprovalWorkflow/src/CustomEntity/ApprovalRequestDefinition.php
+++ b/src/B2gApprovalWorkflow/src/CustomEntity/ApprovalRequestDefinition.php
@@ -8,6 +8,7 @@ use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CreatedAtField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\DateTimeField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
@@ -15,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\UpdatedAtField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 
 /**
@@ -51,8 +53,8 @@ class ApprovalRequestDefinition extends EntityDefinition
             new DateTimeField('decided_at', 'decidedAt'),
             new JsonField('payload', 'payload'),
             (new BoolField('is_escalated', 'isEscalated')),
-            new DateTimeField('created_at', 'createdAt'),
-            new DateTimeField('updated_at', 'updatedAt'),
+            new CreatedAtField(),
+            new UpdatedAtField(),
         ]);
     }
 }

--- a/src/B2gApprovalWorkflow/src/Subscriber/ApprovalSubscriber.php
+++ b/src/B2gApprovalWorkflow/src/Subscriber/ApprovalSubscriber.php
@@ -35,13 +35,19 @@ class ApprovalSubscriber implements EventSubscriberInterface
             return;
         }
 
+        $orderCustomer = $order->getOrderCustomer();
+
+        if ($orderCustomer === null || $orderCustomer->getCustomerId() === null) {
+            return;
+        }
+
         $this->approvalRequestRepository->create([
             [
                 'id' => Uuid::randomHex(),
                 'orderId' => $order->getId(),
                 'status' => 'pending',
-                'requestedById' => $order->getOrderCustomer()?->getCustomerId(),
-                'requestedAt' => (new DateTimeImmutable())->format(DATE_ATOM),
+                'requestedById' => $orderCustomer->getCustomerId(),
+                'requestedAt' => new DateTimeImmutable(),
                 'payload' => [
                     'orderNumber' => $order->getOrderNumber(),
                     'amountTotal' => $order->getAmountTotal(),


### PR DESCRIPTION
## Summary
- replace manual created_at/updated_at fields with Shopware timestamp field classes to ensure automatic persistence
- guard against missing order customers and store requestedAt as a \DateTimeImmutable instead of a formatted string when creating approval requests

## Testing
- php -l src/B2gApprovalWorkflow/src/CustomEntity/ApprovalRequestDefinition.php
- php -l src/B2gApprovalWorkflow/src/Subscriber/ApprovalSubscriber.php

------
https://chatgpt.com/codex/tasks/task_e_68daff7fe90c832980ac8258d209fac5